### PR TITLE
Add PhoneFrame component

### DIFF
--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { Battery, Wifi, Shield } from "lucide-react";
+import { cn } from "../lib/utils";
+
+const PhoneFrame = ({
+  children,
+  statusBarColor = "bg-gray-900",
+  batteryLevel = 100,
+  networkStrength = 4,
+  threatLevel = 0,
+}) => {
+  const [time, setTime] = useState(
+    new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(
+        new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      );
+    }, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="relative w-full max-w-xs aspect-[9/16] border rounded-2xl overflow-hidden bg-black text-green-400 flex flex-col">
+      <div className={cn("flex items-center justify-between text-xs px-2 py-1", statusBarColor)}>
+        <span>{time}</span>
+        <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-1">
+            <Battery className="w-4 h-4" />
+            <span>{batteryLevel}%</span>
+          </div>
+          <div className="flex items-center space-x-1">
+            <Wifi className="w-4 h-4" />
+            <span>{networkStrength}</span>
+          </div>
+          <div className="flex items-center space-x-1">
+            <Shield className="w-4 h-4" />
+            <span>{threatLevel}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto">{children}</div>
+      <div className="flex justify-around items-center p-2 border-t border-gray-700 bg-gray-900/60">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="w-8 h-8 bg-gray-800 rounded-md" />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+PhoneFrame.propTypes = {
+  children: PropTypes.node,
+  statusBarColor: PropTypes.string,
+  batteryLevel: PropTypes.number,
+  networkStrength: PropTypes.number,
+  threatLevel: PropTypes.number,
+};
+
+export default PhoneFrame;


### PR DESCRIPTION
## Summary
- create `PhoneFrame` React component
- implement status bar with time, battery, network and threat indicators
- include main content area and bottom app dock
- add PropTypes for configurable props

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850c8282b888320913d33b29d6a56ca