### PR TITLE
Add AppIcon component

### DIFF
--- a/src/__tests__/AppIcon.test.jsx
+++ b/src/__tests__/AppIcon.test.jsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AppIcon from '../components/AppIcon';
+import { Cpu } from 'lucide-react';
+
+test('shows lock overlay when locked', () => {
+  const { getByTestId } = render(
+    <AppIcon appId="test" name="Terminal" icon={<Cpu />} isLocked={true} isDraggable={false} />
+  );
+  expect(getByTestId('lock-overlay')).toBeInTheDocument();
+});

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Lock } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+const AppIcon = ({
+  appId,
+  name,
+  icon,
+  isLocked = false,
+  isDraggable = false,
+  onDragStart,
+  onDragEnd,
+}) => {
+  const [dragging, setDragging] = useState(false);
+
+  const handleDragStart = (e) => {
+    setDragging(true);
+    if (onDragStart) {
+      onDragStart(appId, e);
+    }
+  };
+
+  const handleDragEnd = (e) => {
+    setDragging(false);
+    if (onDragEnd) {
+      onDragEnd(appId, e);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center w-16">
+      <div
+        draggable={isDraggable && !isLocked}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        className={cn(
+          'relative w-16 h-16 flex items-center justify-center rounded-lg bg-gray-800 text-white',
+          dragging && 'ring-2 ring-green-400 ring-offset-2 animate-pulse'
+        )}
+      >
+        {icon}
+        {isLocked && (
+          <div
+            data-testid="lock-overlay"
+            className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-lg"
+          >
+            <Lock className="w-6 h-6 text-white" />
+          </div>
+        )}
+      </div>
+      <div className="mt-1 w-full text-xs text-center truncate text-white">
+        {name}
+      </div>
+    </div>
+  );
+};
+
+AppIcon.propTypes = {
+  appId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  icon: PropTypes.node.isRequired,
+  isLocked: PropTypes.bool,
+  isDraggable: PropTypes.bool,
+  onDragStart: PropTypes.func,
+  onDragEnd: PropTypes.func,
+};
+
+export default AppIcon;


### PR DESCRIPTION
## Summary
- add new `AppIcon` UI component
- test locked icon overlay

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ca94e6c08320a68c73bcdfda8960