### PR TITLE
Implement drag-and-drop command blocks

### DIFF
--- a/src/__tests__/DragComponents.test.jsx
+++ b/src/__tests__/DragComponents.test.jsx
@@ -1,0 +1,34 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DragCommandBlock from '../components/drag/DragCommandBlock';
+import DropZone from '../components/drag/DropZone';
+
+function createDataTransfer(cmd) {
+  const dt = {
+    data: {},
+    setData(type, val) { this.data[type] = val; },
+    getData(type) { return this.data[type]; },
+  };
+  if (cmd) dt.setData('text/plain', cmd);
+  return dt;
+}
+
+test('drag command sets dataTransfer', () => {
+  const { getByText } = render(<DragCommandBlock command="test" />);
+  const block = getByText('test');
+  const dt = createDataTransfer();
+  fireEvent.dragStart(block, { dataTransfer: dt });
+  expect(dt.getData('text/plain')).toBe('test');
+});
+
+test('drop zone calls handler on drop', () => {
+  const handleDrop = jest.fn();
+  const { getByTestId } = render(
+    <DropZone onDropCommand={handleDrop} data-testid="zone">DROP HERE</DropZone>
+  );
+  const zone = getByTestId('zone');
+  const dt = createDataTransfer('cmd');
+  fireEvent.dragOver(zone, { dataTransfer: dt });
+  fireEvent.drop(zone, { dataTransfer: dt });
+  expect(handleDrop).toHaveBeenCalledWith('cmd');
+});

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Card } from "../components/ui/card";
 import Particles from "./Particles";
+import DragCommandBlock from "./drag/DragCommandBlock";
+import DropZone from "./drag/DropZone";
 import {
   AlertCircle,
   Brain,
@@ -735,6 +737,11 @@ TIPS FOR THIS CHALLENGE:
       question: "COMPLETE THE SETUP SCRIPT:",
       type: "script",
       script: `ufw ____\nufw allow 22\nufw enable`,
+      options: [
+        "default deny incoming",
+        "allow http",
+        "status",
+      ],
       correct: "default deny incoming",
       explanation: "Firewall active with SSH access only.",
       icon: <Shield className="w-8 h-8 text-green-500" />,
@@ -986,22 +993,20 @@ TIPS FOR THIS CHALLENGE:
         return (
           <div className="space-y-4">
             <pre className="text-green-400 font-mono text-sm whitespace-pre-wrap border border-green-500/30 p-2 rounded">
-              {currentLevel.script}
+              {currentLevel.script.replace('____', gameState.blankInput || '____')}
             </pre>
-            <div className="flex items-center border border-green-500/30 rounded-lg overflow-hidden">
-              <span className="text-green-500 px-2">&gt;</span>
-              <input
-                type="text"
-                value={gameState.blankInput}
-                onChange={(e) =>
-                  setGameState((prev) => ({
-                    ...prev,
-                    blankInput: e.target.value,
-                  }))
-                }
-                className="flex-1 bg-transparent border-none text-green-400 font-mono p-2 focus:outline-none"
-                placeholder="Fill the blank..."
-              />
+            <DropZone
+              onDropCommand={(cmd) =>
+                setGameState((prev) => ({ ...prev, blankInput: cmd }))
+              }
+              className="mb-2"
+            >
+              {gameState.blankInput || 'DROP COMMAND HERE'}
+            </DropZone>
+            <div className="flex flex-wrap gap-2">
+              {currentLevel.options.map((cmd, i) => (
+                <DragCommandBlock key={i} command={cmd} />
+              ))}
             </div>
             <button
               onClick={() => handleAnswer()}

--- a/src/components/drag/DragCommandBlock.jsx
+++ b/src/components/drag/DragCommandBlock.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+
+const DragCommandBlock = ({ command, className }) => {
+  const handleDragStart = (e) => {
+    e.dataTransfer.setData('text/plain', command);
+  };
+
+  return (
+    <div
+      draggable
+      onDragStart={handleDragStart}
+      className={cn(
+        'bg-black border border-green-500/30 text-green-400 font-mono px-3 py-1 rounded-lg cursor-grab active:cursor-grabbing select-none',
+        className,
+      )}
+    >
+      {command}
+    </div>
+  );
+};
+
+DragCommandBlock.propTypes = {
+  command: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+export default DragCommandBlock;

--- a/src/components/drag/DropZone.jsx
+++ b/src/components/drag/DropZone.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+
+const DropZone = ({ onDropCommand, children, className, ...props }) => {
+  const [over, setOver] = useState(false);
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const cmd = e.dataTransfer.getData('text/plain');
+    if (cmd && onDropCommand) onDropCommand(cmd);
+    setOver(false);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    setOver(true);
+  };
+
+  const handleDragLeave = () => setOver(false);
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      className={cn(
+        'min-h-[40px] flex items-center justify-center border border-dashed rounded-md text-green-400',
+        over ? 'border-green-400 bg-green-900/30' : 'border-green-500/30',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+DropZone.propTypes = {
+  onDropCommand: PropTypes.func,
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default DropZone;


### PR DESCRIPTION
## Summary
- add `DragCommandBlock` and `DropZone` components for drag interactions
- update script challenge to use drag-and-drop blocks
- include drag component unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850dc0cf5a48320b7b782e3c0bc49b7