### PR TITLE
Add basic script builder system

### DIFF
--- a/src/__tests__/scriptValidator.test.js
+++ b/src/__tests__/scriptValidator.test.js
@@ -1,0 +1,17 @@
+import { validateScript } from '../lib/scriptValidator';
+
+test('accepts valid script', () => {
+  const result = validateScript(['init', 'step', 'end']);
+  expect(result.valid).toBe(true);
+});
+
+test('rejects missing init', () => {
+  const result = validateScript(['step', 'end']);
+  expect(result.valid).toBe(false);
+});
+
+test('rejects too long script', () => {
+  const cmds = ['init', ...Array(9).fill('step'), 'end'];
+  const result = validateScript(cmds);
+  expect(result.valid).toBe(false);
+});

--- a/src/components/scriptbuilder/CommandLibrary.jsx
+++ b/src/components/scriptbuilder/CommandLibrary.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import DragCommandBlock from '../drag/DragCommandBlock';
+
+const COMMANDS = ['init', 'step', 'wait', 'end'];
+
+const CommandLibrary = () => {
+  return (
+    <div className="space-y-2" data-testid="command-library">
+      {COMMANDS.map(cmd => (
+        <DragCommandBlock key={cmd} command={cmd} />
+      ))}
+    </div>
+  );
+};
+
+export default CommandLibrary;

--- a/src/components/scriptbuilder/ExecutionVisualizer.jsx
+++ b/src/components/scriptbuilder/ExecutionVisualizer.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const ExecutionVisualizer = ({ commands, onComplete }) => {
+  const [current, setCurrent] = useState(-1);
+
+  useEffect(() => {
+    if (!commands || commands.length === 0) return;
+    setCurrent(-1);
+    let index = 0;
+    const id = setInterval(() => {
+      setCurrent(index);
+      index += 1;
+      if (index >= commands.length) {
+        clearInterval(id);
+        if (onComplete) onComplete();
+      }
+    }, 300);
+    return () => clearInterval(id);
+  }, [commands, onComplete]);
+
+  return (
+    <div className="space-y-1 mt-2" data-testid="execution-visualizer">
+      {commands.map((cmd, i) => (
+        <div
+          key={i}
+          className={
+            i === current
+              ? 'text-black bg-green-400 rounded px-2'
+              : 'text-green-400'
+          }
+        >
+          {cmd}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+ExecutionVisualizer.propTypes = {
+  commands: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onComplete: PropTypes.func,
+};
+
+export default ExecutionVisualizer;

--- a/src/components/scriptbuilder/ScriptBuilder.jsx
+++ b/src/components/scriptbuilder/ScriptBuilder.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import DropZone from '../drag/DropZone';
+import CommandLibrary from './CommandLibrary';
+import TemplateSelector from './TemplateSelector';
+import ExecutionVisualizer from './ExecutionVisualizer';
+import { validateScript } from '../../lib/scriptValidator';
+
+const ScriptBuilder = () => {
+  const [commands, setCommands] = useState([]);
+  const [exec, setExec] = useState(null);
+  const [error, setError] = useState(null);
+
+  const addCommand = (cmd) => {
+    setCommands((prev) => [...prev, cmd]);
+  };
+
+  const loadTemplate = (tpl) => {
+    if (tpl) setCommands(tpl);
+  };
+
+  const runScript = () => {
+    const result = validateScript(commands);
+    if (!result.valid) {
+      setError(result.error);
+      return;
+    }
+    setError(null);
+    setExec(commands);
+  };
+
+  return (
+    <div className="p-4 space-y-4" data-testid="script-builder">
+      <TemplateSelector onSelect={loadTemplate} />
+      <div className="flex space-x-4">
+        <CommandLibrary />
+        <DropZone
+          onDropCommand={addCommand}
+          className="flex-1 min-h-[100px] p-2"
+          data-testid="script-dropzone"
+        >
+          <div className="space-y-1">
+            {commands.map((c, i) => (
+              <div key={i} className="text-green-400">
+                {i + 1}. {c}
+              </div>
+            ))}
+          </div>
+        </DropZone>
+      </div>
+      <button
+        className="border border-green-500 text-green-400 rounded px-3 py-1"
+        onClick={runScript}
+      >
+        Run Script
+      </button>
+      {error && <div className="text-red-400">{error}</div>}
+      {exec && <ExecutionVisualizer commands={exec} onComplete={() => setExec(null)} />}
+    </div>
+  );
+};
+
+export default ScriptBuilder;

--- a/src/components/scriptbuilder/TemplateSelector.jsx
+++ b/src/components/scriptbuilder/TemplateSelector.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TEMPLATES = {
+  bash: ['init', 'end'],
+  python: ['init', 'end'],
+};
+
+const TemplateSelector = ({ onSelect }) => {
+  return (
+    <select
+      onChange={e => onSelect(TEMPLATES[e.target.value])}
+      className="border rounded-md p-1 bg-black text-green-400"
+      data-testid="template-selector"
+    >
+      <option value="">Select Template</option>
+      {Object.keys(TEMPLATES).map(name => (
+        <option key={name} value={name}>
+          {name}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+TemplateSelector.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+};
+
+export default TemplateSelector;

--- a/src/components/scriptbuilder/index.js
+++ b/src/components/scriptbuilder/index.js
@@ -1,0 +1,1 @@
+export { default as ScriptBuilderScreen } from './ScriptBuilder';

--- a/src/lib/appRegistry.js
+++ b/src/lib/appRegistry.js
@@ -78,6 +78,16 @@ export const appRegistry = {
     description: 'Break encrypted archives and messages.',
     launchScreen: 'DecryptorScreen',
   },
+  scriptBuilder: {
+    id: 'scriptBuilder',
+    name: 'Script Builder',
+    icon: 'ClipboardList',
+    category: 'tools',
+    isLocked: false,
+    unlockRequirements: [],
+    description: 'Visually assemble and test command scripts.',
+    launchScreen: 'ScriptBuilderScreen',
+  },
 
   handbook: {
     id: 'handbook',

--- a/src/lib/scriptValidator.js
+++ b/src/lib/scriptValidator.js
@@ -1,0 +1,18 @@
+export function validateScript(commands) {
+  if (!Array.isArray(commands)) {
+    return { valid: false, error: 'Invalid script format' };
+  }
+  if (commands.length === 0) {
+    return { valid: false, error: 'Script is empty' };
+  }
+  if (commands[0] !== 'init') {
+    return { valid: false, error: 'Script must start with "init"' };
+  }
+  if (commands[commands.length - 1] !== 'end') {
+    return { valid: false, error: 'Script must end with "end"' };
+  }
+  if (commands.length > 10) {
+    return { valid: false, error: 'Script exceeds max length' };
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary
- add a `scriptBuilder` tool entry to app registry
- implement a drag-and-drop script builder UI with command library and template selector
- create script validation logic and unit tests
- visualize script execution steps

## Testing
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6850f8633b9c8320bb761581e9fd55ad