### PR TITLE
Implement ScriptBuilder Canvas

### DIFF
--- a/src/__tests__/ScriptBuilderCanvas.test.jsx
+++ b/src/__tests__/ScriptBuilderCanvas.test.jsx
@@ -1,0 +1,51 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScriptBuilderCanvas from '../components/scriptbuilder/ScriptBuilderCanvas';
+
+function createDataTransfer(data) {
+  return {
+    data: {},
+    setData(type, val) { this.data[type] = val; },
+    getData(type) { return this.data[type]; },
+    dropEffect: '',
+    effectAllowed: 'all'
+  };
+}
+
+describe('ScriptBuilderCanvas', () => {
+  const commands = [
+    { type: 'init', icon: 'Terminal', parameters: {} },
+    { type: 'end', icon: 'Square', parameters: {} },
+  ];
+
+  test('renders palette and canvas', () => {
+    const { getByTestId } = render(
+      <ScriptBuilderCanvas availableCommands={commands} />
+    );
+    expect(getByTestId('command-palette')).toBeInTheDocument();
+    expect(getByTestId('script-canvas')).toBeInTheDocument();
+  });
+
+  test('drops command onto canvas', () => {
+    const { getByTestId, getAllByText } = render(
+      <ScriptBuilderCanvas availableCommands={commands} />
+    );
+    const paletteItem = getAllByText('init')[0];
+    const dt = createDataTransfer();
+    fireEvent.dragStart(paletteItem, { dataTransfer: dt });
+    const canvas = getByTestId('script-canvas');
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0 });
+    fireEvent.dragOver(canvas, { dataTransfer: dt });
+    fireEvent.drop(canvas, { dataTransfer: dt, clientX: 10, clientY: 10 });
+    expect(canvas.querySelector('[data-testid=canvas-block]')).toBeInTheDocument();
+  });
+
+  test('calls onScriptComplete', () => {
+    const handleComplete = jest.fn();
+    const { getByText } = render(
+      <ScriptBuilderCanvas availableCommands={commands} onScriptComplete={handleComplete} />
+    );
+    fireEvent.click(getByText('Complete'));
+    expect(handleComplete).toHaveBeenCalled();
+  });
+});

--- a/src/components/scriptbuilder/ScriptBuilderCanvas.jsx
+++ b/src/components/scriptbuilder/ScriptBuilderCanvas.jsx
@@ -1,0 +1,168 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import * as Icons from 'lucide-react';
+function snap(value) {
+  return Math.round(value / 50) * 50;
+}
+
+const PaletteItem = ({ command }) => {
+  const Icon = Icons[command.icon] || Icons.Terminal;
+  const handleDragStart = (e) => {
+    e.dataTransfer.setData('command', JSON.stringify(command));
+  };
+  return (
+    <div
+      draggable
+      onDragStart={handleDragStart}
+      className="flex items-center space-x-1 bg-black border border-green-500/30 text-green-400 px-2 py-1 rounded-md cursor-grab active:cursor-grabbing select-none"
+    >
+      <Icon className="w-4 h-4" />
+      <span>{command.type}</span>
+    </div>
+  );
+};
+
+PaletteItem.propTypes = {
+  command: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    parameters: PropTypes.object,
+    icon: PropTypes.string,
+  }).isRequired,
+};
+
+const CanvasBlock = ({ block, onMouseDown }) => {
+  const Icon = Icons[block.icon] || Icons.Terminal;
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      className="absolute w-12 h-12 flex items-center justify-center border border-green-500/30 bg-black text-green-400 rounded select-none cursor-grab active:cursor-grabbing"
+      style={{ left: block.x, top: block.y }}
+      data-testid="canvas-block"
+    >
+      <Icon className="w-5 h-5" />
+    </div>
+  );
+};
+
+CanvasBlock.propTypes = {
+  block: PropTypes.shape({
+    id: PropTypes.number,
+    type: PropTypes.string,
+    parameters: PropTypes.object,
+    icon: PropTypes.string,
+    x: PropTypes.number,
+    y: PropTypes.number,
+  }).isRequired,
+  onMouseDown: PropTypes.func.isRequired,
+};
+
+const ScriptBuilderCanvas = ({ availableCommands = [], onScriptComplete }) => {
+  const canvasRef = useRef(null);
+  const [blocks, setBlocks] = useState([]);
+  const [dragging, setDragging] = useState(null);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const data = e.dataTransfer.getData('command');
+    if (!data) return;
+    const cmd = JSON.parse(data);
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = snap(e.clientX - rect.left);
+    const y = snap(e.clientY - rect.top);
+    const id = Date.now() + Math.random();
+    setBlocks((prev) => [...prev, { ...cmd, id, x, y }]);
+  };
+
+  const handleDragOver = (e) => e.preventDefault();
+
+  const startDrag = (id) => (e) => {
+    const rect = canvasRef.current.getBoundingClientRect();
+    const block = blocks.find((b) => b.id === id);
+    if (!block) return;
+    setDragging(id);
+    setOffset({ x: e.clientX - rect.left - block.x, y: e.clientY - rect.top - block.y });
+  };
+
+  const handleMouseMove = (e) => {
+    if (dragging === null) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = snap(e.clientX - rect.left - offset.x);
+    const y = snap(e.clientY - rect.top - offset.y);
+    setBlocks((prev) => prev.map((b) => (b.id === dragging ? { ...b, x, y } : b)));
+  };
+
+  const handleMouseUp = () => setDragging(null);
+
+  const completeScript = () => {
+    if (onScriptComplete) onScriptComplete(blocks);
+  };
+
+  const sorted = blocks.slice();
+  sorted.sort((a, b) => a.y - b.y);
+
+  return (
+    <div className="flex space-x-4">
+      {/* Command Palette */}
+      <div className="space-y-2" data-testid="command-palette">
+        {availableCommands.map((cmd) => (
+          <PaletteItem key={cmd.type} command={cmd} />
+        ))}
+      </div>
+
+      {/* Canvas */}
+      <div className="relative flex-1 border border-green-500/30" style={{ minHeight: 300 }}
+        ref={canvasRef}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        data-testid="script-canvas"
+      >
+        <svg className="absolute inset-0 pointer-events-none" data-testid="lines">
+          {sorted.map((b, i) => {
+            if (i === 0) return null;
+            const prev = sorted[i - 1];
+            return (
+              <line
+                key={b.id}
+                x1={prev.x + 24}
+                y1={prev.y + 24}
+                x2={b.x + 24}
+                y2={b.y + 24}
+                stroke="#22c55e"
+                strokeWidth="2"
+              />
+            );
+          })}
+        </svg>
+        {blocks.map((b) => (
+          <CanvasBlock key={b.id} block={b} onMouseDown={startDrag(b.id)} />
+        ))}
+      </div>
+
+      <div className="flex flex-col justify-start">
+        <button
+          type="button"
+          onClick={completeScript}
+          className="border border-green-500 text-green-400 rounded px-2 py-1"
+        >
+          Complete
+        </button>
+      </div>
+    </div>
+  );
+};
+
+ScriptBuilderCanvas.propTypes = {
+  availableCommands: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string.isRequired,
+      parameters: PropTypes.object,
+      icon: PropTypes.string,
+    })
+  ),
+  onScriptComplete: PropTypes.func,
+};
+
+export default ScriptBuilderCanvas;

--- a/src/components/scriptbuilder/index.js
+++ b/src/components/scriptbuilder/index.js
@@ -1,1 +1,2 @@
 export { default as ScriptBuilderScreen } from './ScriptBuilder';
+export { default as ScriptBuilderCanvas } from './ScriptBuilderCanvas';


### PR DESCRIPTION
## Summary
- add visual `ScriptBuilderCanvas` for dragging commands onto a canvas
- export `ScriptBuilderCanvas` from scriptbuilder index
- test component behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68517f01cbf08320872a48970b19b6bc