### PR TITLE
Add NetworkScanner with tests

### DIFF
--- a/src/__tests__/NetworkScanner.test.jsx
+++ b/src/__tests__/NetworkScanner.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NetworkScanner from '../components/NetworkScanner';
+
+test('scan generates devices after delay', () => {
+  jest.useFakeTimers();
+  render(<NetworkScanner />);
+  fireEvent.click(screen.getByText('Scan'));
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  const devices = screen.getAllByTestId(/device/);
+  expect(devices.length).toBeGreaterThanOrEqual(3);
+  expect(devices.length).toBeLessThanOrEqual(5);
+  expect(screen.getByTestId('bad-device')).toBeInTheDocument();
+  jest.useRealTimers();
+});
+
+test('clicking device shows details panel', () => {
+  jest.useFakeTimers();
+  render(<NetworkScanner />);
+  fireEvent.click(screen.getByText('Scan'));
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  const device = screen.getAllByTestId('device')[0];
+  fireEvent.click(device);
+  expect(screen.getByText(/IP:/i)).toBeInTheDocument();
+  expect(screen.getByText(/Type:/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});

--- a/src/components/NetworkScanner.jsx
+++ b/src/components/NetworkScanner.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+
+const DEVICE_TYPES = ['Camera', 'Terminal', 'Laptop', 'Drone', 'Sensor'];
+const VULN_LEVELS = ['Low', 'Medium', 'High', 'Critical'];
+
+function randomIp() {
+  return `192.168.${Math.floor(Math.random() * 256)}.${Math.floor(
+    Math.random() * 256
+  )}`;
+}
+
+function generateDevices() {
+  const count = 3 + Math.floor(Math.random() * 3); // 3-5
+  const devices = Array.from({ length: count }).map((_, i) => ({
+    id: i,
+    ip: randomIp(),
+    type: DEVICE_TYPES[Math.floor(Math.random() * DEVICE_TYPES.length)],
+    vulnerability: VULN_LEVELS[Math.floor(Math.random() * VULN_LEVELS.length)],
+    x: Math.random() * 90 + 5,
+    y: Math.random() * 90 + 5,
+  }));
+  const badIndex = Math.floor(Math.random() * count);
+  devices[badIndex].isBad = true;
+  return devices;
+}
+
+const NetworkScanner = () => {
+  const [devices, setDevices] = useState([]);
+  const [scanning, setScanning] = useState(false);
+  const [selected, setSelected] = useState(null);
+
+  const startScan = () => {
+    setScanning(true);
+    setDevices([]);
+    setSelected(null);
+    setTimeout(() => {
+      setDevices(generateDevices());
+      setScanning(false);
+    }, 3000);
+  };
+
+  return (
+    <div className="p-4 space-y-4" data-testid="network-scanner">
+      <div className="relative w-64 h-64 mx-auto">
+        <div className="absolute inset-0 rounded-full border border-green-500 overflow-hidden">
+          <div className="radar-lines" />
+        </div>
+        <div className="radar-sweep" />
+        {devices.map((d) => (
+          <button
+            key={d.id}
+            type="button"
+            className={`absolute w-2 h-2 rounded-full ${
+              d.isBad ? 'bg-red-500 animate-pulse' : 'bg-green-500'
+            }`}
+            style={{ left: `${d.x}%`, top: `${d.y}%` }}
+            onClick={() => setSelected(d)}
+            data-testid={d.isBad ? 'bad-device' : 'device'}
+          />
+        ))}
+      </div>
+      <button
+        onClick={startScan}
+        className="border border-green-500 text-green-400 rounded px-3 py-1"
+        disabled={scanning}
+      >
+        {scanning ? 'Scanning...' : 'Scan'}
+      </button>
+      {selected && (
+        <div className="text-green-400 border border-green-500 rounded p-2">
+          <div>IP: {selected.ip}</div>
+          <div>Type: {selected.type}</div>
+          <div>Vulnerability: {selected.vulnerability}</div>
+          {selected.isBad && <div className="text-red-400">TARGET DEVICE</div>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NetworkScanner;

--- a/src/index.css
+++ b/src/index.css
@@ -45,3 +45,29 @@
   to { transform: translateY(-150px); opacity: 0; }
 }
 
+
+/* Radar sweep animation */
+.radar-lines::before,
+.radar-lines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  border: 1px dashed rgba(16,185,129,0.4);
+}
+.radar-lines::after {
+  transform: rotate(90deg);
+}
+
+.radar-sweep {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: conic-gradient(rgba(16,185,129,0.4) 0deg, rgba(16,185,129,0) 60deg);
+  animation: radar-rotate 2s linear infinite;
+}
+
+@keyframes radar-rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- add interactive NetworkScanner component
- style radar sweep animation in CSS
- test scanning behavior and device details

## Testing
- `CI=true npm test -- NetworkScanner.test.jsx --watchAll=false`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6851812338208320a42a0dab9856f8d9