### PR TITLE
Implement threat generator module

### DIFF
--- a/src/__tests__/threatGenerator.test.js
+++ b/src/__tests__/threatGenerator.test.js
@@ -1,0 +1,37 @@
+import { generateThreat } from '../lib/threatGenerator';
+
+const components = ['net', 'db'];
+
+function mockRandomSequence(values) {
+  let i = 0;
+  jest.spyOn(Math, 'random').mockImplementation(() => {
+    const val = values[i % values.length];
+    i += 1;
+    return val;
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('generates threat with required properties', () => {
+  mockRandomSequence([0, 0, 0, 0]);
+  const threat = generateThreat(1, components);
+  expect(threat).toHaveProperty('id');
+  expect(threat).toHaveProperty('type');
+  expect(threat).toHaveProperty('severity');
+  expect(threat).toHaveProperty('timeToImpact');
+  expect(threat).toHaveProperty('target');
+  expect(['malware', 'phishing', 'bruteforce', 'backdoor']).toContain(threat.type);
+  expect(threat.severity).toBeGreaterThanOrEqual(1);
+  expect(threat.severity).toBeLessThanOrEqual(5);
+  expect(components).toContain(threat.target);
+});
+
+test('higher difficulty increases severity', () => {
+  mockRandomSequence([0.9, 0.9, 0, 0]);
+  const low = generateThreat(1, components);
+  const high = generateThreat(5, components);
+  expect(high.severity).toBeGreaterThan(low.severity);
+});

--- a/src/lib/threatGenerator.js
+++ b/src/lib/threatGenerator.js
@@ -1,0 +1,42 @@
+export const THREAT_TYPES = ['malware', 'phishing', 'bruteforce', 'backdoor'];
+export const DEFAULT_COMPONENTS = ['network', 'database', 'services', 'kernel'];
+
+let nextId = 1;
+
+export function generateThreat(difficulty = 1, components = DEFAULT_COMPONENTS) {
+  const type = THREAT_TYPES[Math.floor(Math.random() * THREAT_TYPES.length)];
+  const severity = Math.min(5, Math.max(1, Math.ceil(Math.random() * difficulty)));
+  const timeToImpact = Math.max(5, Math.floor(30 - difficulty * 2 + Math.random() * 5));
+  const target = components[Math.floor(Math.random() * components.length)];
+  return {
+    id: nextId++,
+    type,
+    severity,
+    timeToImpact,
+    target,
+  };
+}
+
+export function startThreatGenerator(callback, components = DEFAULT_COMPONENTS) {
+  let difficulty = 1;
+  let active = true;
+  let timeoutId;
+
+  function schedule() {
+    if (!active) return;
+    const delay = 10000 + Math.random() * 20000;
+    timeoutId = setTimeout(() => {
+      const threat = generateThreat(difficulty, components);
+      difficulty += 0.5;
+      callback(threat);
+      schedule();
+    }, delay);
+  }
+
+  schedule();
+
+  return () => {
+    active = false;
+    clearTimeout(timeoutId);
+  };
+}


### PR DESCRIPTION
## Summary
- add `threatGenerator` for dynamic threat creation and scheduling
- test threat generator logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68519d13a6fc8320afe59ab65c40e492