### PR TITLE
Add ThreatIndicator component

### DIFF
--- a/src/__tests__/ThreatIndicator.test.jsx
+++ b/src/__tests__/ThreatIndicator.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ThreatIndicator from '../components/ThreatIndicator';
+
+const baseThreats = [
+  { id: 1, type: 'malware', severity: 3, timeRemaining: 5 },
+  { id: 2, type: 'phishing', severity: 2, timeRemaining: 10 },
+];
+
+test('shows threat count and lists sorted threats', () => {
+  render(<ThreatIndicator threats={baseThreats} />);
+  expect(screen.getByText(/Threats: 2/)).toBeInTheDocument();
+  const items = screen.getAllByRole('listitem');
+  expect(items[0].textContent).toMatch('malware');
+  expect(items[1].textContent).toMatch('phishing');
+});
+
+test('flashes red when critical threat present', () => {
+  const threats = [
+    { id: 3, type: 'ddos', severity: 5, timeRemaining: 6 },
+  ];
+  const { getByTestId } = render(<ThreatIndicator threats={threats} />);
+  expect(getByTestId('threat-indicator')).toHaveClass('animate-pulse');
+});
+
+test('calls onThreatClick when clicked', () => {
+  const handle = jest.fn();
+  const { getByTestId } = render(
+    <ThreatIndicator threats={baseThreats} onThreatClick={handle} />
+  );
+  fireEvent.click(getByTestId('threat-indicator'));
+  expect(handle).toHaveBeenCalled();
+});
+
+test('counts down timers each second', () => {
+  jest.useFakeTimers();
+  render(<ThreatIndicator threats={baseThreats} />);
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+  const item = screen.getAllByRole('listitem')[0];
+  expect(item.textContent).toMatch('4s');
+  jest.useRealTimers();
+});

--- a/src/components/ThreatIndicator.jsx
+++ b/src/components/ThreatIndicator.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { AlertTriangle } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+/**
+ * Displays a list of active threats with countdown timers.
+ * Flashes red when a critical threat is present.
+ *
+ * @param {{
+ *  threats: {id:string|number,type:string,severity:number,timeRemaining:number}[],
+ *  onThreatClick?: Function
+ * }} props
+ */
+const ThreatIndicator = ({ threats = [], onThreatClick }) => {
+  const [localThreats, setLocalThreats] = useState(() =>
+    threats.map((t) => ({ ...t }))
+  );
+
+  useEffect(() => {
+    setLocalThreats(threats.map((t) => ({ ...t })));
+  }, [threats]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLocalThreats((ts) =>
+        ts.map((t) => ({
+          ...t,
+          timeRemaining: Math.max(0, t.timeRemaining - 1),
+        }))
+      );
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const sorted = [...localThreats].sort((a, b) => {
+    if (b.severity !== a.severity) return b.severity - a.severity;
+    return a.timeRemaining - b.timeRemaining;
+  });
+
+  const critical = sorted.some((t) => t.severity >= 4 || t.severity >= 80);
+
+  return (
+    <div
+      data-testid="threat-indicator"
+      onClick={onThreatClick}
+      className={cn(
+        'border p-2 rounded text-green-400 cursor-pointer select-none',
+        critical && 'border-red-500 text-red-400 animate-pulse'
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span>Threats: {sorted.length}</span>
+        {critical && <AlertTriangle className="w-4 h-4" />}
+      </div>
+      <ul className="mt-1 space-y-1 text-xs">
+        {sorted.map((t) => (
+          <li key={t.id} className="flex justify-between">
+            <span>
+              {t.type} (s{t.severity})
+            </span>
+            <span>{t.timeRemaining}s</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+ThreatIndicator.propTypes = {
+  threats: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      type: PropTypes.string.isRequired,
+      severity: PropTypes.number.isRequired,
+      timeRemaining: PropTypes.number.isRequired,
+    })
+  ),
+  onThreatClick: PropTypes.func,
+};
+
+export default ThreatIndicator;


### PR DESCRIPTION
## Summary
- add new ThreatIndicator component for listing and tracking threats
- show threat count, sort items, flash when critical
- expose click handler
- test the new component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68519f44d2cc832092df1fa6dc5b52e5