### PR TITLE
Add script templates

### DIFF
--- a/src/components/scriptbuilder/ExecutionVisualizer.jsx
+++ b/src/components/scriptbuilder/ExecutionVisualizer.jsx
@@ -21,18 +21,21 @@ const ExecutionVisualizer = ({ commands, onComplete }) => {
 
   return (
     <div className="space-y-1 mt-2" data-testid="execution-visualizer">
-      {commands.map((cmd, i) => (
-        <div
-          key={i}
-          className={
-            i === current
-              ? 'text-black bg-green-400 rounded px-2'
-              : 'text-green-400'
-          }
-        >
-          {cmd}
-        </div>
-      ))}
+      {commands.map((cmd, i) => {
+        const label = typeof cmd === 'string' ? cmd : cmd.type;
+        return (
+          <div
+            key={i}
+            className={
+              i === current
+                ? 'text-black bg-green-400 rounded px-2'
+                : 'text-green-400'
+            }
+          >
+            {label}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/scriptbuilder/ScriptBuilder.jsx
+++ b/src/components/scriptbuilder/ScriptBuilder.jsx
@@ -39,11 +39,14 @@ const ScriptBuilder = () => {
           data-testid="script-dropzone"
         >
           <div className="space-y-1">
-            {commands.map((c, i) => (
-              <div key={i} className="text-green-400">
-                {i + 1}. {c}
-              </div>
-            ))}
+            {commands.map((c, i) => {
+              const label = typeof c === 'string' ? c : c.type;
+              return (
+                <div key={i} className="text-green-400">
+                  {i + 1}. {label}
+                </div>
+              );
+            })}
           </div>
         </DropZone>
       </div>

--- a/src/components/scriptbuilder/TemplateSelector.jsx
+++ b/src/components/scriptbuilder/TemplateSelector.jsx
@@ -1,9 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { scriptTemplates } from '../../lib/scriptTemplates';
 
 const TEMPLATES = {
   bash: ['init', 'end'],
   python: ['init', 'end'],
+  basicScan: scriptTemplates.basicScan,
+  attack: scriptTemplates.attack,
+  defense: scriptTemplates.defense,
+};
+
+const LABELS = {
+  bash: 'bash',
+  python: 'python',
+  basicScan: 'Basic Scan Script',
+  attack: 'Attack Script',
+  defense: 'Defense Script',
 };
 
 const TemplateSelector = ({ onSelect }) => {
@@ -16,7 +28,7 @@ const TemplateSelector = ({ onSelect }) => {
       <option value="">Select Template</option>
       {Object.keys(TEMPLATES).map(name => (
         <option key={name} value={name}>
-          {name}
+          {LABELS[name] || name}
         </option>
       ))}
     </select>

--- a/src/lib/scriptTemplates.js
+++ b/src/lib/scriptTemplates.js
@@ -1,0 +1,21 @@
+export const scriptTemplates = {
+  basicScan: [
+    { type: 'START', x: 0, y: 0, parameters: {} },
+    { type: 'SCAN', x: 0, y: 50, parameters: {} },
+    { type: 'REPORT', x: 0, y: 100, parameters: {} },
+    { type: 'END', x: 0, y: 150, parameters: {} },
+  ],
+  attack: [
+    { type: 'START', x: 0, y: 0, parameters: {} },
+    { type: 'SELECT_TARGET', x: 0, y: 50, parameters: {} },
+    { type: 'ATTACK', x: 0, y: 100, parameters: {} },
+    { type: 'END', x: 0, y: 150, parameters: {} },
+  ],
+  defense: [
+    { type: 'START', x: 0, y: 0, parameters: {} },
+    { type: 'DETECT', x: 0, y: 50, parameters: {} },
+    { type: 'BLOCK', x: 0, y: 100, parameters: {} },
+    { type: 'LOG', x: 0, y: 150, parameters: {} },
+    { type: 'END', x: 0, y: 200, parameters: {} },
+  ],
+};


### PR DESCRIPTION
## Summary
- create `scriptTemplates.js` with new script boilerplates
- load templates in `TemplateSelector` and show descriptive labels
- show template block types in `ScriptBuilder` and `ExecutionVisualizer`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851a7a8f38c8320bf303cf67d6df9b5