### PR TITLE
Add practice mode sandbox

### DIFF
--- a/src/components/PracticeMode.jsx
+++ b/src/components/PracticeMode.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ApocalypseGame from './Game';
+
+const PracticeMode = () => <ApocalypseGame practice />;
+
+export default PracticeMode;

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import Game from './components/Game';
+import PracticeMode from './components/PracticeMode';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const params = new URLSearchParams(window.location.search);
+const isPractice = params.has('practice');
+
 root.render(
   <React.StrictMode>
-    <Game />
+    {isPractice ? <PracticeMode /> : <Game />}
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- enable Game component to run in practice mode
- save/load practice state separately
- disable random attacks and damage in practice
- add reset button for practice sessions
- render PracticeMode when `?practice` query param is present

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851aa69e61083208396291d8b9b69f9