### PR TITLE
Add advanced GlitchEffect component

### DIFF
--- a/src/__tests__/GlitchEffect.test.jsx
+++ b/src/__tests__/GlitchEffect.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GlitchEffect from '../components/GlitchEffect';
+
+test('applies css variables and active class', () => {
+  const { getByTestId } = render(
+    <GlitchEffect intensity={7} duration={1000} active>
+      <span>Damage</span>
+    </GlitchEffect>
+  );
+  const el = getByTestId('glitch-effect');
+  expect(el).toHaveClass('glitch-active');
+  expect(el.style.getPropertyValue('--glitch-intensity')).toBe('7');
+  expect(el.style.getPropertyValue('--glitch-duration')).toBe('1000ms');
+  expect(el.querySelector('.glitch-noise')).toBeInTheDocument();
+});

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Card } from "../components/ui/card";
 import Particles from "./Particles";
+import GlitchEffect from "./GlitchEffect";
 import DragCommandBlock from "./drag/DragCommandBlock";
 import DropZone from "./drag/DropZone";
 import {
@@ -1246,11 +1247,15 @@ TIPS FOR THIS CHALLENGE:
               <div className="h-2 w-2 bg-green-500 rounded-full animate-pulse"></div>
             </div>
 
-            <pre
-              className={`text-green-400 font-mono text-sm mb-4 whitespace-pre-wrap ${gameState.glitch ? "glitch" : ""}`}
+            <GlitchEffect
+              intensity={6}
+              duration={500}
+              active={gameState.glitch}
             >
-              {gameState.message}
-            </pre>
+              <pre className="text-green-400 font-mono text-sm mb-4 whitespace-pre-wrap">
+                {gameState.message}
+              </pre>
+            </GlitchEffect>
 
             {gameState.showHint && (
               <div className="border border-yellow-500/30 rounded-lg p-3 mb-4 bg-yellow-900/10">

--- a/src/components/GlitchEffect.jsx
+++ b/src/components/GlitchEffect.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { cn } from '../lib/utils';
+
+const GlitchEffect = ({ intensity = 5, duration = 500, children, active = false }) => {
+  const style = {
+    '--glitch-intensity': intensity,
+    '--glitch-duration': `${duration}ms`,
+  };
+  return (
+    <span
+      data-testid="glitch-effect"
+      style={style}
+      className={cn('glitch-effect', active && 'glitch-active')}
+    >
+      {children}
+      <span className="glitch-noise" aria-hidden="true" />
+    </span>
+  );
+};
+
+GlitchEffect.propTypes = {
+  intensity: PropTypes.number,
+  duration: PropTypes.number,
+  active: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default GlitchEffect;

--- a/src/index.css
+++ b/src/index.css
@@ -71,3 +71,54 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* Advanced GlitchEffect animations */
+.glitch-effect {
+  --glitch-intensity: 5;
+  --glitch-duration: 500ms;
+  position: relative;
+  display: inline-block;
+}
+
+.glitch-active {
+  animation: glitch-shake var(--glitch-duration);
+  filter: drop-shadow(calc(var(--glitch-intensity) * 1px) 0 red)
+          drop-shadow(calc(var(--glitch-intensity) * -1px) 0 blue);
+}
+
+.glitch-noise {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(255,255,255,0.05) 0px,
+    rgba(255,255,255,0.05) 2px,
+    rgba(0,0,0,0.05) 2px,
+    rgba(0,0,0,0.05) 4px
+  );
+  opacity: 0;
+}
+
+.glitch-active .glitch-noise {
+  animation: noise-move var(--glitch-duration);
+  opacity: 0.2;
+}
+
+@keyframes glitch-shake {
+  0%,100% { transform: translate(0,0); }
+  10% { transform: translate(calc(var(--glitch-intensity) * -1px), calc(var(--glitch-intensity) * -1px)); }
+  20% { transform: translate(calc(var(--glitch-intensity) * 1px), calc(var(--glitch-intensity) * -1px)); }
+  30% { transform: translate(calc(var(--glitch-intensity) * -1px), calc(var(--glitch-intensity) * 1px)); }
+  40% { transform: translate(calc(var(--glitch-intensity) * 1px), calc(var(--glitch-intensity) * 1px)); }
+  50% { transform: translate(calc(var(--glitch-intensity) * -0.5px), calc(var(--glitch-intensity) * 0.5px)); }
+  60% { transform: translate(calc(var(--glitch-intensity) * 0.5px), calc(var(--glitch-intensity) * -0.5px)); }
+  70% { transform: translate(calc(var(--glitch-intensity) * -1px), 0); }
+  80% { transform: translate(calc(var(--glitch-intensity) * 1px), 0); }
+  90% { transform: translate(0, calc(var(--glitch-intensity) * 1px)); }
+}
+
+@keyframes noise-move {
+  0% { transform: translate(0,0); }
+  100% { transform: translate(-50%, -50%); }
+}


### PR DESCRIPTION
## Summary
- create reusable `GlitchEffect` component
- extend CSS with advanced glitch animations
- integrate GlitchEffect into `Game` display
- test GlitchEffect behaviour

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6851b9beb7b883208cc0966a313aa077