### PR TITLE
Add PacketFlow visualization component

### DIFF
--- a/src/__tests__/PacketFlow.test.jsx
+++ b/src/__tests__/PacketFlow.test.jsx
@@ -1,0 +1,65 @@
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PacketFlow from '../components/PacketFlow';
+import { allocateResources, resetResources } from '../lib/resourceSystem';
+
+beforeEach(() => {
+  resetResources();
+});
+
+test('renders correct number of packets and color', () => {
+  const { getAllByTestId } = render(
+    <PacketFlow
+      source={{ x: 0, y: 0 }}
+      destination={{ x: 50, y: 0 }}
+      packetType="malware"
+      count={3}
+    />,
+  );
+  const dots = getAllByTestId('packet-dot');
+  expect(dots).toHaveLength(3);
+  expect(dots[0]).toHaveClass('bg-red-500');
+});
+
+test('speed decreases with higher bandwidth', () => {
+  allocateResources('net', { bandwidth: 80 });
+  const { getByTestId, rerender } = render(
+    <PacketFlow
+      source={{ x: 0, y: 0 }}
+      destination={{ x: 100, y: 0 }}
+      packetType="http"
+      count={1}
+    />,
+  );
+  const fast = getByTestId('packet-dot').style.transitionDuration;
+  resetResources();
+  rerender(
+    <PacketFlow
+      source={{ x: 0, y: 0 }}
+      destination={{ x: 100, y: 0 }}
+      packetType="http"
+      count={1}
+    />,
+  );
+  const slow = getByTestId('packet-dot').style.transitionDuration;
+  expect(parseFloat(fast)).toBeLessThan(parseFloat(slow));
+});
+
+test('animates to destination', () => {
+  jest.useFakeTimers();
+  const { getByTestId } = render(
+    <PacketFlow
+      source={{ x: 0, y: 0 }}
+      destination={{ x: 20, y: 10 }}
+      packetType="ftp"
+      count={1}
+    />,
+  );
+  const dot = getByTestId('packet-dot');
+  act(() => {
+    jest.advanceTimersByTime(50);
+  });
+  expect(dot.style.transform).toMatch('translate(20px, 10px)');
+  jest.useRealTimers();
+});
+

--- a/src/components/PacketFlow.jsx
+++ b/src/components/PacketFlow.jsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { getUsage } from '../lib/resourceSystem';
+
+const TYPE_COLORS = {
+  http: 'bg-blue-500',
+  ftp: 'bg-yellow-500',
+  malware: 'bg-red-500',
+  default: 'bg-green-400',
+};
+
+const PacketFlow = ({ source, destination, packetType, count }) => {
+  const [animate, setAnimate] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setAnimate(true), 20);
+    return () => clearTimeout(t);
+  }, [source, destination, count]);
+
+  const { bandwidth } = getUsage();
+  const duration = Math.max(0.5, 5 - bandwidth / 25);
+
+  const sx = source.x;
+  const sy = source.y;
+  const dx = destination.x;
+  const dy = destination.y;
+
+  const color = TYPE_COLORS[packetType] || TYPE_COLORS.default;
+
+  return (
+    <div className="absolute inset-0 pointer-events-none" data-testid="packet-flow">
+      {Array.from({ length: count }).map((_, i) => (
+        <span
+          key={i}
+          data-testid="packet-dot"
+          className={`rounded-full absolute w-2 h-2 ${color}`}
+          style={{
+            left: `${sx}px`,
+            top: `${sy}px`,
+            transform: animate ? `translate(${dx - sx}px, ${dy - sy}px)` : 'translate(0,0)',
+            transitionProperty: 'transform',
+            transitionDuration: `${duration}s`,
+            transitionTimingFunction: 'linear',
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+PacketFlow.propTypes = {
+  source: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }).isRequired,
+  destination: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }).isRequired,
+  packetType: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+export default PacketFlow;
+


### PR DESCRIPTION
## Summary
- implement `PacketFlow` component to animate data packet movement
- create accompanying unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851c50857c08320b7c24082e16f3422