### PR TITLE
Add HomeScreen component

### DIFF
--- a/src/__tests__/HomeScreen.test.jsx
+++ b/src/__tests__/HomeScreen.test.jsx
@@ -1,0 +1,54 @@
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HomeScreen from '../components/HomeScreen';
+import { appRegistry } from '../lib/appRegistry';
+
+function createDataTransfer(appId) {
+  const dt = {
+    data: {},
+    setData(type, val) { this.data[type] = val; },
+    getData(type) { return this.data[type]; },
+  };
+  if (appId) dt.setData('text/plain', appId);
+  return dt;
+}
+
+test('renders search bar and grid slots', () => {
+  localStorage.clear();
+  const { getByTestId, container } = render(<HomeScreen />);
+  expect(getByTestId('search-bar')).toBeInTheDocument();
+  const slots = container.querySelectorAll('[data-testid^="grid-slot-"]');
+  expect(slots.length).toBe(20);
+});
+
+test('dragging app reorganizes grid', () => {
+  localStorage.clear();
+  const firstId = Object.keys(appRegistry)[0];
+  const { container } = render(<HomeScreen />);
+  const slot0 = container.querySelector('[data-testid="grid-slot-0"]');
+  const slot1 = container.querySelector('[data-testid="grid-slot-1"]');
+  const icon = slot0.querySelector('[draggable="true"]');
+  const dt = createDataTransfer(firstId);
+  fireEvent.dragStart(icon, { dataTransfer: dt });
+  fireEvent.dragOver(slot1, { dataTransfer: dt });
+  fireEvent.drop(slot1, { dataTransfer: dt });
+  const stored = JSON.parse(localStorage.getItem('homeGridSlots'));
+  expect(stored[1]).toBe(firstId);
+});
+
+test('long press uninstalls app', () => {
+  jest.useFakeTimers();
+  window.confirm = jest.fn(() => true);
+  localStorage.clear();
+  const firstId = Object.keys(appRegistry)[0];
+  const { container } = render(<HomeScreen />);
+  const slot0 = container.querySelector('[data-testid="grid-slot-0"]');
+  fireEvent.pointerDown(slot0);
+  act(() => {
+    jest.advanceTimersByTime(600);
+  });
+  expect(window.confirm).toHaveBeenCalled();
+  const stored = JSON.parse(localStorage.getItem('homeGridSlots'));
+  expect(stored[0]).toBeNull();
+  jest.useRealTimers();
+});

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import * as Icons from 'lucide-react';
+import { appRegistry } from '../lib/appRegistry';
+import { cn } from '../lib/utils';
+import AppIcon from './AppIcon';
+import DockBar from './DockBar';
+import { getUsage } from '../lib/resourceSystem';
+
+const GRID_KEY = 'homeGridSlots';
+
+function loadDefaultGrid() {
+  const ids = Object.keys(appRegistry).slice(0, 20);
+  return ids.concat(Array(20 - ids.length).fill(null));
+}
+
+const HomeScreen = ({ notifications = [] }) => {
+  const [gridSlots, setGridSlots] = useState(() => {
+    const saved = localStorage.getItem(GRID_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (Array.isArray(parsed) && parsed.length === 20) return parsed;
+      } catch {
+        /* ignore */
+      }
+    }
+    return loadDefaultGrid();
+  });
+
+  useEffect(() => {
+    localStorage.setItem(GRID_KEY, JSON.stringify(gridSlots));
+  }, [gridSlots]);
+
+  const [overIndex, setOverIndex] = useState(null);
+
+  const handleDrop = (index) => (e) => {
+    e.preventDefault();
+    setOverIndex(null);
+    const id = e.dataTransfer.getData('text/plain');
+    if (!id) return;
+    setGridSlots((prev) => {
+      const from = prev.indexOf(id);
+      if (from === -1) return prev;
+      const updated = [...prev];
+      const tmp = updated[index];
+      updated[index] = id;
+      updated[from] = tmp;
+      return updated;
+    });
+  };
+
+  const handleDragOver = (index) => (e) => {
+    e.preventDefault();
+    setOverIndex(index);
+  };
+  const handleDragLeave = () => setOverIndex(null);
+
+  const longPress = useRef(null);
+  const handlePointerDown = (index) => () => {
+    if (!gridSlots[index]) return;
+    longPress.current = setTimeout(() => {
+      if (window.confirm('Uninstall app?')) {
+        setGridSlots((prev) => {
+          const updated = [...prev];
+          updated[index] = null;
+          return updated;
+        });
+      }
+    }, 600);
+  };
+  const cancelLongPress = () => clearTimeout(longPress.current);
+
+  const [search, setSearch] = useState('');
+
+  const [usage, setUsage] = useState(getUsage());
+  useEffect(() => {
+    const t = setInterval(() => setUsage(getUsage()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full p-2 space-y-2" data-testid="home-screen">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search"
+        className="w-full px-2 py-1 rounded bg-gray-800 text-green-400"
+        data-testid="search-bar"
+      />
+      <div className="text-xs text-green-400 flex justify-around border border-gray-700 rounded p-1" data-testid="status-widgets">
+        <div>CPU {usage.cpu}%</div>
+        <div>RAM {usage.ram}%</div>
+        <div>BW {usage.bandwidth}%</div>
+      </div>
+      <div className="flex-1 overflow-auto">
+        <div className="grid grid-cols-4 gap-2" data-testid="app-grid">
+          {gridSlots.map((appId, i) => {
+            const def = appRegistry[appId];
+            const Icon = def ? Icons[def.icon] : null;
+            const hidden = search && def && !def.name.toLowerCase().includes(search.toLowerCase());
+            return (
+              <div
+                key={i}
+                onDrop={handleDrop(i)}
+                onDragOver={handleDragOver(i)}
+                onDragLeave={handleDragLeave}
+                onPointerDown={handlePointerDown(i)}
+                onPointerUp={cancelLongPress}
+                onPointerMove={cancelLongPress}
+                className={cn(
+                  'w-full h-20 flex items-center justify-center rounded border',
+                  overIndex === i ? 'border-green-400 bg-gray-700/50' : 'border-gray-700 bg-gray-800'
+                )}
+                data-testid={`grid-slot-${i}`}
+              >
+                {!hidden && def && Icon && (
+                  <AppIcon
+                    appId={def.id}
+                    name={def.name}
+                    icon={<Icon className="w-6 h-6" />}
+                    isDraggable
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {notifications.length > 0 && (
+        <div className="text-xs text-green-400 space-y-1" data-testid="notifications">
+          {notifications.map((n) => (
+            <div key={n.id}>{n.message}</div>
+          ))}
+        </div>
+      )}
+      <DockBar />
+    </div>
+  );
+};
+
+HomeScreen.propTypes = {
+  notifications: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      message: PropTypes.string.isRequired,
+    })
+  ),
+};
+
+export default HomeScreen;


### PR DESCRIPTION
## Summary
- add home screen showing searchable app grid
- allow dragging to reorganize grid apps
- support long press uninstall
- display system status and notifications
- test HomeScreen component

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ce84a2ec83209ab955afa1fd3921