### PR TITLE
Add mission structure definitions

### DIFF
--- a/src/__tests__/missionStructure.test.js
+++ b/src/__tests__/missionStructure.test.js
@@ -1,0 +1,19 @@
+import { sampleMission } from '../lib/missionStructure';
+
+/** Basic shape validation for the mission structure */
+test('sample mission has required properties', () => {
+  expect(sampleMission).toHaveProperty('id');
+  expect(sampleMission).toHaveProperty('name');
+  expect(sampleMission).toHaveProperty('briefing');
+  expect(sampleMission).toHaveProperty('objectives');
+  expect(sampleMission).toHaveProperty('unlockReward');
+  expect(sampleMission).toHaveProperty('requiredApps');
+  expect(Array.isArray(sampleMission.objectives)).toBe(true);
+  sampleMission.objectives.forEach((obj) => {
+    expect(obj).toHaveProperty('id');
+    expect(obj).toHaveProperty('description');
+    expect(obj).toHaveProperty('type');
+    expect(obj).toHaveProperty('target');
+    expect(obj).toHaveProperty('completed');
+  });
+});

--- a/src/lib/missionStructure.js
+++ b/src/lib/missionStructure.js
@@ -1,0 +1,40 @@
+/**
+ * Mission related type definitions and sample mission data.
+ *
+ * @typedef {Object} MissionObjective
+ * @property {string} id - Unique identifier for the objective.
+ * @property {string} description - Text explaining the objective.
+ * @property {string} type - Category of objective.
+ * @property {string} target - Target this objective references.
+ * @property {boolean} completed - Whether the objective is complete.
+ */
+
+/**
+ * @typedef {Object} Mission
+ * @property {string} id - Unique mission id.
+ * @property {string} name - Display name of the mission.
+ * @property {string} briefing - Mission briefing shown to the player.
+ * @property {MissionObjective[]} objectives - Objectives required to finish.
+ * @property {string} unlockReward - App id unlocked on completion.
+ * @property {number} [timeLimit] - Optional time limit in seconds.
+ * @property {string[]} requiredApps - IDs of prerequisite apps.
+ */
+
+/** @type {Mission} */
+export const sampleMission = {
+  id: 'example',
+  name: 'Example Mission',
+  briefing: 'Demonstrates the mission structure.',
+  objectives: [
+    {
+      id: 'obj1',
+      description: 'Complete the first step',
+      type: 'tutorial',
+      target: 'system',
+      completed: false,
+    },
+  ],
+  unlockReward: 'map',
+  timeLimit: 300,
+  requiredApps: ['communicator'],
+};


### PR DESCRIPTION
## Summary
- define `MissionObjective` and `Mission` types
- provide `sampleMission` object
- test mission structure

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851da0f73988320b076cd10f1117664