### PR TITLE
Implement save system

### DIFF
--- a/src/__tests__/saveSystem.test.js
+++ b/src/__tests__/saveSystem.test.js
@@ -1,0 +1,22 @@
+import { saveGame, loadGame, resetGame } from '../lib/saveSystem';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('saves and loads game data', () => {
+  saveGame({ currentScreen: 'home', unlockedApps: ['map'], completedMissions: ['m1'] });
+  const data = loadGame();
+  expect(data).toMatchObject({
+    version: 1,
+    currentScreen: 'home',
+    unlockedApps: ['map'],
+    completedMissions: ['m1'],
+  });
+});
+
+test('resetGame clears saved data', () => {
+  saveGame({ currentScreen: 'home', unlockedApps: [], completedMissions: [] });
+  resetGame();
+  expect(loadGame()).toBeNull();
+});

--- a/src/hooks/usePhoneState.js
+++ b/src/hooks/usePhoneState.js
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { loadGame, startAutoSave } from '../lib/saveSystem';
 
 /**
  * @typedef {Object} Threat
@@ -35,6 +36,7 @@ export const initialPhoneState = {
   currentScreen: 'lock',
   unlockedApps: [],
   installedApps: [],
+  completedMissions: [],
   systemHealth: 100,
   batteryLevel: 100,
   networkStrength: 5,
@@ -48,5 +50,22 @@ export const initialPhoneState = {
  * @returns {[typeof initialPhoneState, Function]}
  */
 export default function usePhoneState() {
-  return useState(initialPhoneState);
+  const [state, setState] = useState(() => {
+    const saved = loadGame();
+    if (saved) {
+      return { ...initialPhoneState, ...saved };
+    }
+    return initialPhoneState;
+  });
+
+  useEffect(() => {
+    const stop = startAutoSave(() => ({
+      currentScreen: state.currentScreen,
+      unlockedApps: state.unlockedApps,
+      completedMissions: state.completedMissions,
+    }));
+    return stop;
+  }, [state]);
+
+  return [state, setState];
 }

--- a/src/lib/saveSystem.js
+++ b/src/lib/saveSystem.js
@@ -1,0 +1,60 @@
+const STORAGE_KEY = 'survivos-save';
+const VERSION = 1;
+
+/**
+ * Saves relevant game data to localStorage.
+ *
+ * @param {{currentScreen:string, unlockedApps:string[], completedMissions:string[]}} state
+ */
+export function saveGame(state) {
+  const data = {
+    version: VERSION,
+    currentScreen: state.currentScreen,
+    unlockedApps: state.unlockedApps || [],
+    completedMissions: state.completedMissions || [],
+  };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    /* ignore write errors */
+  }
+}
+
+/**
+ * Loads saved game data from localStorage.
+ * @returns {{version:number, currentScreen:string, unlockedApps:string[], completedMissions:string[]}|null}
+ */
+export function loadGame() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clears saved game data.
+ */
+export function resetGame() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Starts an auto-save interval that saves using the provided getter.
+ * Returns a cleanup function to stop the interval.
+ *
+ * @param {Function} getState - Function returning current state object.
+ * @param {number} [interval=30000] - Interval in ms.
+ */
+export function startAutoSave(getState, interval = 30000) {
+  const save = () => saveGame(getState());
+  const id = setInterval(save, interval);
+  return () => clearInterval(id);
+}


### PR DESCRIPTION
## Summary
- add saveSystem library for serializing game state
- persist phone state with auto-save
- cover new module with unit tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851dbab3a7c83208a7c64921d489e4b