### PR TITLE
Add missing app screens

### DIFF
--- a/src/components/CommunicatorScreen.jsx
+++ b/src/components/CommunicatorScreen.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+/**
+ * Simple encrypted messaging interface. Players can send messages and attempt
+ * to decrypt intercepted transmissions using a basic ROT13 cipher.
+ */
+const CommunicatorScreen = () => {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [decoded, setDecoded] = useState('');
+
+  const intercepted = 'Guvf vf n frperg zrffntr';
+
+  const sendMessage = () => {
+    if (!input.trim()) return;
+    setMessages((m) => [...m, { id: Date.now(), text: input }]);
+    setInput('');
+  };
+
+  const decode = () => {
+    const rot13 = (str) =>
+      str.replace(/[A-Za-z]/g, (c) =>
+        "NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm"[
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".indexOf(c)
+        ]
+      );
+    setDecoded(rot13(intercepted));
+  };
+
+  return (
+    <div className="p-4 space-y-4" data-testid="communicator-screen">
+      <div className="space-y-2">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type encoded message"
+          className="w-full h-20 bg-gray-800 border border-green-500/30 rounded p-1"
+        />
+        <button
+          onClick={sendMessage}
+          className="border border-green-500 text-green-400 rounded px-3 py-1"
+        >
+          Send
+        </button>
+      </div>
+      {messages.length > 0 && (
+        <div className="space-y-1 text-green-400" data-testid="message-log">
+          {messages.map((m) => (
+            <div key={m.id}>&gt; {m.text}</div>
+          ))}
+        </div>
+      )}
+      <div className="space-y-2" data-testid="intercepted">
+        <div className="text-green-200">Intercepted: {intercepted}</div>
+        <button
+          onClick={decode}
+          className="border border-green-500 text-green-400 rounded px-3 py-1"
+        >
+          Decrypt
+        </button>
+        {decoded && <div className="text-green-400">{decoded}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default CommunicatorScreen;

--- a/src/components/DecryptorScreen.jsx
+++ b/src/components/DecryptorScreen.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+/**
+ * Decryptor utility supporting Caesar and Base64 ciphers.
+ */
+const DecryptorScreen = () => {
+  const [method, setMethod] = useState('caesar');
+  const [input, setInput] = useState('');
+  const [output, setOutput] = useState('');
+
+  const decrypt = () => {
+    if (method === 'base64') {
+      try {
+        setOutput(atob(input));
+      } catch {
+        setOutput('Invalid base64');
+      }
+    } else {
+      const shift = 3;
+      const result = input.replace(/[a-z]/gi, (c) => {
+        const base = c <= 'Z' ? 65 : 97;
+        return String.fromCharCode(
+          ((c.charCodeAt(0) - base - shift + 26) % 26) + base
+        );
+      });
+      setOutput(result);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-2" data-testid="decryptor-screen">
+      <select
+        value={method}
+        onChange={(e) => setMethod(e.target.value)}
+        className="bg-gray-800 border border-green-500/30 rounded p-1"
+      >
+        <option value="caesar">Caesar</option>
+        <option value="base64">Base64</option>
+      </select>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Ciphertext"
+        className="w-full h-20 bg-gray-800 border border-green-500/30 rounded p-1"
+      />
+      <button
+        onClick={decrypt}
+        className="border border-green-500 text-green-400 rounded px-3 py-1"
+      >
+        Decrypt
+      </button>
+      {output && <div className="text-green-400 break-words">{output}</div>}
+    </div>
+  );
+};
+
+export default DecryptorScreen;

--- a/src/components/DroneScreen.jsx
+++ b/src/components/DroneScreen.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+/**
+ * Drone control interface for basic reconnaissance.
+ * Players can launch a drone and receive random scan results.
+ */
+const DroneScreen = () => {
+  const [log, setLog] = useState([]);
+  const [active, setActive] = useState(false);
+
+  const launch = () => {
+    setActive(true);
+    setLog([]);
+    const messages = [
+      'Scanning sector...',
+      'No hostiles detected',
+      'Cache spotted',
+      'Radiation spike detected',
+    ];
+    messages.forEach((m, i) => {
+      setTimeout(() => {
+        setLog((l) => [...l, m]);
+        if (i === messages.length - 1) setActive(false);
+      }, 1000 * (i + 1));
+    });
+  };
+
+  return (
+    <div className="p-4 space-y-2" data-testid="drone-screen">
+      <button
+        onClick={launch}
+        disabled={active}
+        className="border border-green-500 text-green-400 rounded px-3 py-1"
+      >
+        {active ? 'Deploying...' : 'Launch Drone'}
+      </button>
+      <div className="text-green-400 space-y-1">
+        {log.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DroneScreen;

--- a/src/components/HandbookScreen.jsx
+++ b/src/components/HandbookScreen.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/**
+ * Survival handbook containing short references.
+ */
+const sections = [
+  {
+    title: 'Security Basics',
+    text: 'Always secure your terminals and rotate keys frequently.',
+  },
+  {
+    title: 'Command Reference',
+    text: 'Use `ls`, `cd`, and `cat` to explore the file system.',
+  },
+  {
+    title: 'Survival Tips',
+    text: 'Avoid radiation hotspots and scavenge safe houses for supplies.',
+  },
+];
+
+const HandbookScreen = () => (
+  <div className="p-4 space-y-4" data-testid="handbook-screen">
+    {sections.map((s) => (
+      <div key={s.title}>
+        <h3 className="text-green-400 font-semibold">{s.title}</h3>
+        <p className="text-green-200 text-sm">{s.text}</p>
+      </div>
+    ))}
+  </div>
+);
+
+export default HandbookScreen;

--- a/src/components/LogScreen.jsx
+++ b/src/components/LogScreen.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+
+/**
+ * Viewer for intercepted signal logs.
+ */
+const LogScreen = () => {
+  const [logs] = useState([
+    { id: 1, text: 'Encrypted ping from sector 7' },
+    { id: 2, text: 'Old broadcast decoded: keep moving' },
+    { id: 3, text: 'Distress call triangulated near canyon' },
+  ]);
+
+  return (
+    <div className="p-4 space-y-1 text-green-400" data-testid="log-screen">
+      {logs.map((l) => (
+        <div key={l.id}>- {l.text}</div>
+      ))}
+    </div>
+  );
+};
+
+export default LogScreen;

--- a/src/components/MapScreen.jsx
+++ b/src/components/MapScreen.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Displays a simple wasteland map with placeholder points of interest.
+ */
+const MapScreen = () => {
+  const locations = [
+    { id: 'player', label: 'You', x: 40, y: 70, color: 'bg-blue-500' },
+    { id: 'safe', label: 'Safe House', x: 20, y: 20, color: 'bg-green-500' },
+    { id: 'cache', label: 'Supply Cache', x: 70, y: 35, color: 'bg-yellow-500' },
+    { id: 'rad', label: 'Radiation Zone', x: 55, y: 55, color: 'bg-red-500' },
+  ];
+
+  return (
+    <div className="p-4" data-testid="map-screen">
+      <div className="relative w-full h-64 border border-green-500 rounded">
+        {locations.map((loc) => (
+          <div
+            key={loc.id}
+            className={`absolute w-3 h-3 rounded-full ${loc.color}`}
+            style={{ left: `${loc.x}%`, top: `${loc.y}%` }}
+            title={loc.label}
+          />
+        ))}
+      </div>
+      <ul className="mt-2 text-green-400 space-y-1">
+        {locations.map((l) => (
+          <li key={l.id}>{l.label}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MapScreen;

--- a/src/components/ScannerScreen.jsx
+++ b/src/components/ScannerScreen.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+/**
+ * Environmental scanner displaying nearby threats and hidden items.
+ */
+const ScannerScreen = () => {
+  const [results, setResults] = useState([]);
+  const [scanning, setScanning] = useState(false);
+
+  const scan = () => {
+    setScanning(true);
+    setResults([]);
+    const sample = [
+      'Low radiation levels',
+      'Hostile signature detected',
+      'Hidden access point found',
+      'Signal strength weak',
+    ];
+    sample.forEach((r, i) => {
+      setTimeout(() => {
+        setResults((res) => [...res, r]);
+        if (i === sample.length - 1) setScanning(false);
+      }, 800 * (i + 1));
+    });
+  };
+
+  return (
+    <div className="p-4 space-y-2" data-testid="scanner-screen">
+      <button
+        onClick={scan}
+        disabled={scanning}
+        className="border border-green-500 text-green-400 rounded px-3 py-1"
+      >
+        {scanning ? 'Scanning...' : 'Scan Environment'}
+      </button>
+      <ul className="text-green-400 space-y-1">
+        {results.map((r, i) => (
+          <li key={i}>{r}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ScannerScreen;

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * Displays world statistics such as radiation and threat levels.
+ */
+const StatsScreen = () => {
+  const stats = {
+    radiation: 'Moderate',
+    threats: 'Low',
+    progress: '12%',
+  };
+
+  return (
+    <div className="p-4 space-y-2 text-green-400" data-testid="stats-screen">
+      <div>Radiation Levels: {stats.radiation}</div>
+      <div>Threat Level: {stats.threats}</div>
+      <div>Progress: {stats.progress}</div>
+    </div>
+  );
+};
+
+export default StatsScreen;

--- a/src/components/TerminalScreen.jsx
+++ b/src/components/TerminalScreen.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+/**
+ * Minimal command-line interface supporting a few demo commands.
+ */
+const fs = {
+  '/': ['home', 'var'],
+  '/home': ['survivor.txt'],
+};
+
+const readFile = {
+  'survivor.txt': 'Stay hidden. Avoid radiation. Keep moving.',
+};
+
+const TerminalScreen = () => {
+  const [cwd, setCwd] = useState('/');
+  const [history, setHistory] = useState([]);
+  const [input, setInput] = useState('');
+
+  const run = () => {
+    const parts = input.trim().split(' ');
+    const cmd = parts[0];
+    const arg = parts[1];
+    let out = '';
+    if (cmd === 'ls') {
+      out = (fs[cwd] || []).join(' ');
+    } else if (cmd === 'cd') {
+      const path = arg === '..' ? '/' : `${cwd === '/' ? '' : cwd}/${arg}`;
+      if (fs[path]) setCwd(path);
+    } else if (cmd === 'cat') {
+      out = readFile[arg] || 'file not found';
+    } else {
+      out = `unknown command: ${cmd}`;
+    }
+    setHistory((h) => [...h, `$ ${input}`, out]);
+    setInput('');
+  };
+
+  return (
+    <div className="p-2 font-mono text-green-400" data-testid="terminal-screen">
+      <div className="h-60 overflow-auto bg-black p-2 border border-green-500 mb-2 space-y-1">
+        {history.map((h, i) => (
+          <div key={i}>{h}</div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <span className="shrink-0">{cwd} $</span>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && run()}
+          className="flex-1 bg-transparent border-b border-green-500 outline-none"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TerminalScreen;


### PR DESCRIPTION
## Summary
- add CommunicatorScreen for encrypted messaging
- add MapScreen showing key locations
- add DroneScreen for reconnaissance
- add ScannerScreen for threat scanning
- add TerminalScreen with simple commands
- add DecryptorScreen for puzzle ciphers
- add HandbookScreen with tips
- add StatsScreen for world data
- add LogScreen to view transmissions

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851df66dcb483208898f01766fd65e8