### PR TITLE
Implement app launch system

### DIFF
--- a/src/__tests__/HomeScreen.test.jsx
+++ b/src/__tests__/HomeScreen.test.jsx
@@ -52,3 +52,23 @@ test('long press uninstalls app', () => {
   expect(stored[0]).toBeNull();
   jest.useRealTimers();
 });
+
+test('tapping unlocked app launches and back returns home', () => {
+  localStorage.clear();
+  const { container, getByTestId } = render(<HomeScreen />);
+  const slot0 = container.querySelector('[data-testid="grid-slot-0"]');
+  const icon = slot0.querySelector('[draggable="true"]');
+  fireEvent.click(icon);
+  expect(getByTestId('communicator-screen')).toBeInTheDocument();
+  fireEvent.click(getByTestId('back-button'));
+  expect(getByTestId('home-screen')).toBeInTheDocument();
+});
+
+test('shows message when launching locked app', () => {
+  localStorage.clear();
+  const { container, getByTestId } = render(<HomeScreen />);
+  const slot1 = container.querySelector('[data-testid="grid-slot-1"]');
+  const icon = slot1.querySelector('[draggable]');
+  fireEvent.click(icon);
+  expect(getByTestId('lock-message')).toBeInTheDocument();
+});

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -11,6 +11,7 @@ const AppIcon = ({
   isDraggable = false,
   onDragStart,
   onDragEnd,
+  onClick,
 }) => {
   const [dragging, setDragging] = useState(false);
 
@@ -34,6 +35,7 @@ const AppIcon = ({
         draggable={isDraggable && !isLocked}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
+        onClick={onClick}
         className={cn(
           'relative w-16 h-16 flex items-center justify-center rounded-lg bg-gray-800 text-white',
           dragging && 'ring-2 ring-green-400 ring-offset-2 animate-pulse'
@@ -64,6 +66,7 @@ AppIcon.propTypes = {
   isDraggable: PropTypes.bool,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 export default AppIcon;


### PR DESCRIPTION
## Summary
- add onClick handler support to `AppIcon`
- build active app launching behavior in `HomeScreen`
- indicate locked apps and show lock messages
- test launching and locked app behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851e6bafaf88320b774217df9cea8fa