### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -1119,7 +1119,7 @@ TIPS FOR THIS CHALLENGE:
   return (
     <div className="min-h-screen bg-black p-4 flex items-center justify-center">
       <div className="matrix-bg" />
-      <div className="w-full max-w-md relative">
+      <div className="w-full relative max-w-md sm:max-w-lg md:max-w-xl lg:max-w-2xl">
         <Particles trigger={gameState.showParticles} />
         {/* Device Frame */}
         <div className="absolute inset-0 border-2 border-green-500 rounded-3xl pointer-events-none"></div>

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -24,7 +24,9 @@ const PhoneFrame = ({
   }, []);
 
   return (
-    <div className="relative w-full max-w-xs aspect-[9/16] border rounded-2xl overflow-hidden bg-black text-green-400 flex flex-col">
+    <div
+      className="relative w-full aspect-[9/16] border rounded-2xl overflow-hidden bg-black text-green-400 flex flex-col max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg"
+    >
       <div className={cn("flex items-center justify-between text-xs px-2 py-1", statusBarColor)}>
         <span>{time}</span>
         <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- widen phone frame for bigger screens with Tailwind responsive utilities
- allow Game layout to scale on larger screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851f660cdc48320a114700dc81fb4e2