### PR TITLE
Add screen tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,289 @@
-# Post-Apocalypse Learn
+# SURVIV-OS: Post-Apocalyptic Security Training Simulator
 
-A small hacking-themed puzzle game built with React. Players progress through security challenges by answering questions, entering commands and sequences. Each correct answer boosts your neural link while mistakes drain system health.
+## 🎮 Overview
 
-Immerse yourself in cinematic cyber missions where you outsmart rival hackers and oppressive regimes. Real command-line techniques are woven into each scenario so you learn as you infiltrate systems and defend your network.
+SURVIV-OS is an interactive cybersecurity training game set in a post-apocalyptic world where radiation, survival, and hacking skills determine your fate. Your mobile device is both your lifeline and your weapon in a world where digital and physical threats merge.
 
-Recent updates introduce interactive security setup challenges. Configure a firewall with UFW and enable fail2ban directly inside the game using script-style prompts.
+In this harsh new reality, you must defend your device from AI-driven attacks while scavenging for digital resources, decoding encrypted survival data, and hacking into abandoned systems. The game transforms complex security concepts into survival necessities - where knowing the correct radiation protocol or binary sequence could mean the difference between life and death.
 
-## Running Locally
+Unlike traditional security training, SURVIV-OS uses intuitive drag-and-drop mechanics, visual programming, and survival-themed puzzles to teach complex concepts without requiring extensive technical knowledge.
 
-1. Install dependencies
+## 🌟 Key Features
+
+### Interactive Phone Interface
+- **Realistic Mobile OS**: Complete with home screen, app drawer, and dock
+- **Drag-and-Drop Apps**: Organize your security tools just like a real phone
+- **Resource Management**: Monitor CPU, RAM, and bandwidth usage
+- **Dynamic Notifications**: Real-time threat alerts and system updates
+
+### Gamified Learning System
+- **Contextual Challenges**: Security questions appear as in-game obstacles
+- **Action-Based Answers**: Solve problems to unlock doors, repair systems, or activate defenses
+- **No Quiz Popups**: Learning integrated seamlessly into gameplay
+- **Instant Rewards**: Correct answers grant tools, health, or special abilities
+- **Dynamic Difficulty**: Challenges adapt based on player performance
+
+### Security Tools & Apps
+- **Network Scanner**: Discover devices and identify threats with visual radar
+- **Port Scanner**: Analyze vulnerabilities in target systems
+- **Firewall Manager**: Configure rules by dragging and dropping policies
+- **DDoS Simulator**: Launch controlled attacks against hostile targets
+- **Packet Analyzer**: Visualize network traffic in real-time
+- **Script Builder**: Create security scripts with visual programming blocks
+- **System Terminal**: Solve security challenges through interactive puzzles
+- **Cipher Decoder**: Decrypt intercepted messages to unlock new capabilities
+- **Protocol Analyzer**: Answer diagnostic queries to repair corrupted systems
+- **Radiation Monitor**: Calibrate Gray protocols to survive in contaminated zones
+- **Emergency Keypad**: Input survival codes to access bunkers and safe zones
+- **Chemical Database**: Query compound formulas for crafting antidotes
+
+### Threat System
+- **AI Opponents**: Rogue AIs from before the collapse still patrol networks
+- **Multiple Attack Types**: Digital malware merges with real-world threats
+  - **Radiation Leaks**: System vulnerabilities expose you to contamination
+  - **Resource Drains**: Attacks on your limited battery and supplies
+  - **Data Corruption**: Loss of vital survival information
+  - **Hostile Survivors**: Other hackers trying to steal your resources
+- **Real-Time Defense**: Respond to threats before they compromise your survival
+- **Environmental Hazards**: Radiation zones require proper protocol knowledge
+- **Escalating Difficulty**: Threats evolve as you venture deeper into the wasteland
+
+### Learning System
+- **Progressive Unlocking**: New tools unlock as you master concepts
+- **Interactive Tutorials**: Guided missions teach each tool's purpose
+- **Practice Mode**: Experiment without time pressure or threats
+- **Real-World Concepts**: Each game mechanic maps to actual security practices
+
+### Visual Programming
+- **Drag-and-Drop Scripts**: Build security scripts without typing code
+- **Command Blocks**: Puzzle-piece style programming interface
+- **Script Templates**: Pre-built boilerplates for common tasks
+- **Visual Validation**: See errors and connections in real-time
+
+### Integrated Learning Challenges
+- **Security Puzzles**: Answer questions disguised as system diagnostics
+- **Protocol Repairs**: Fix corrupted systems by selecting correct protocols
+- **Cipher Challenges**: Decode messages to unlock doors and systems
+- **Binary Conversions**: Input sequences to bypass security locks
+- **Pattern Recognition**: Identify attack signatures to activate defenses
+- **Knowledge Gates**: Answer security questions to unlock new areas
+- **Survival Challenges**: Apply technical knowledge to post-apocalyptic scenarios
+
+### Post-Apocalyptic Integration
+Knowledge challenges appear as survival necessities:
+- **Radiation Protocols**: Select correct measurement units to calibrate hazmat suits
+- **Emergency Keypads**: Enter numeric sequences to access supply bunkers
+- **Chemical Queries**: Complete SQL injections to find antidote formulas
+- **Bunker Overrides**: Input binary codes to unlock blast doors
+- **Encrypted Coordinates**: Decode ciphers to locate safe zones
+- **Network Infiltration**: Hack abandoned facilities for resources
+
+Each challenge rewards correct answers with:
+- **Instant Unlocks**: New apps and tools become available
+- **System Repairs**: Restore health and resources
+- **Power-Ups**: Temporary boosts to scanning speed or defense strength
+- **Access Codes**: Unlock hidden features and secret tools
+- **Shield Generators**: Create temporary protection barriers
+- **Survival Resources**: Gain radiation medicine, battery packs, or data caches
+
+## 🚀 Getting Started
+
+### Prerequisites
+- Node.js (v14 or higher)
+- npm or yarn
+- Modern web browser with ES6 support
+
+### Installation
+
+1. Clone the repository
+   ```bash
+   git clone https://github.com/yourusername/surviv-os.git
+   cd surviv-os
+   ```
+
+2. Install dependencies
    ```bash
    npm install
    ```
-2. Start the development server
+
+3. Start the development server
    ```bash
    npm start
    ```
-   The app will open at `http://localhost:3000`.
 
-## Testing
+4. Open your browser to `http://localhost:3000`
 
-Run the unit tests with:
+### First Time Players
 
+1. **Complete the Boot Sequence**: Learn basic navigation
+2. **Solve the Access Puzzle**: Answer security questions to unlock the main interface
+3. **Unlock Your First App**: Complete a protocol challenge to access the Network Scanner
+4. **Identify Threats**: Use the scanner to find hostile devices
+5. **Decrypt Enemy Plans**: Solve cipher challenges to reveal attack patterns
+6. **Build Defenses**: Configure your firewall to block attacks
+7. **Override Systems**: Answer diagnostic questions to take control
+8. **Launch Counter-Attacks**: Use offensive tools strategically
+
+### Example In-Game Challenges
+
+**Survival-Critical Challenges:**
+- **"Radiation Firewall Compromised"**: Choose the correct protocol (Gray.protocol, Volt.exe, Pascal.sys, or Candela.bin) to restore protection against radiation leaks
+- **"Bunker Door Override"**: Use the emergency keypad to input sequence 4-2-0-3 before contamination spreads
+- **"Chemical Database Breach"**: Complete SQL query "SELECT * FROM compounds WHERE type='organic'" to find edible compounds
+- **"Emergency Broadcast Encrypted"**: Decode 'KHOOR' (Caesar shift 3) to reveal "HELLO" - a survivor beacon
+- **"Contamination Scanner Malfunction"**: Convert decimal 13 to binary (1101) to recalibrate the scanner
+- **"Security Pattern at Safe House"**: Enter displayed sequence 1-2-3-4 on keypad to gain entry
+
+**Network Defense Challenges:**
+- **"Rogue AI Detection"**: Identify which item is NOT malicious (Trojans, Worms, Firewalls, Spyware) to restore defenses
+- **"Secure Channel to Survivors"**: Select TLS protocol to establish encrypted communication
+- **"Encoded Supply Drop Location"**: Decode Base64 'U1VSVklWRQ==' to reveal 'SURVIVE' coordinates
+- **"Firewall Reconfiguration"**: Block port 80 to stop hostile HTTP traffic
+- **"Multicast Beacon Setup"**: Identify Class D IP range for survivor group communications
+- **"Data Integrity Check"**: Select SHA-256 algorithm to verify uncontaminated files
+
+Each challenge maintains the post-apocalyptic theme while teaching real security concepts. The number pad interface appears for bunker access codes, radiation calibration sequences, and emergency overrides - making it feel like using actual survival equipment rather than taking a quiz.
+
+## 🎯 Gameplay Mechanics
+
+### Core Loop
+1. **Scan** for threats using detection tools
+2. **Analyze** vulnerabilities and attack patterns
+3. **Solve** security challenges to unlock defenses
+4. **Defend** by configuring security measures
+5. **Attack** hostile systems to neutralize threats
+6. **Learn** through integrated puzzles and challenges
+7. **Unlock** new tools and capabilities
+
+### Challenge Integration
+Rather than traditional quizzes, knowledge challenges appear as:
+- **System Diagnostics**: "Select the correct protocol to restore firewall"
+- **Decryption Tasks**: "Decode this cipher to access the mainframe"
+- **Repair Sequences**: "Input the binary sequence to reboot the scanner"
+- **Security Audits**: "Identify which service doesn't belong to proceed"
+- **Emergency Overrides**: "Choose the correct port to bypass the lockdown"
+
+Success grants immediate gameplay benefits, while failure triggers defensive mini-games or temporary setbacks.
+
+### Resource Management
+- Each app consumes system resources
+- Running too many tools crashes the system
+- Balance offense and defense within limits
+- Upgrade your device to increase capacity
+
+### Mission Types
+- **Tutorial Missions**: Learn new tools with guided objectives
+- **Defense Scenarios**: Survive waves of increasing threats
+- **Offensive Operations**: Take down hostile networks
+- **Puzzle Challenges**: Solve security problems with limited tools
+- **Boss Battles**: Face advanced persistent threats
+- **Survival Missions**: Combine hacking with resource management
+  - **Bunker Infiltration**: Use keypads and protocols to access supplies
+  - **Radiation Zone Navigation**: Apply Gray protocols to survive contaminated servers
+  - **Chemical Plant Hacking**: Query databases for antidote formulas
+  - **Emergency Broadcast Decoding**: Decrypt survivor communications
+  - **Abandoned Facility Override**: Input sequences to restore power
+- **Hybrid Missions**: Combine action with knowledge challenges
+  - Hack a system by answering protocol questions
+  - Decrypt enemy communications to reveal their plans
+  - Repair damaged systems through diagnostic puzzles
+  - Override security doors with correct command sequences
+
+## 🛠️ Technical Architecture
+
+### Frontend Stack
+- **React 18**: Component-based UI architecture
+- **Tailwind CSS**: Utility-first styling
+- **Lucide Icons**: Consistent iconography
+- **HTML5 Drag & Drop**: Native browser APIs
+
+### Game Systems
+- **State Management**: Centralized game state with React hooks
+- **Component Architecture**: Modular, reusable UI components
+- **Event System**: Real-time threat generation and response
+- **Save System**: LocalStorage persistence with auto-save
+
+### Performance
+- **Optimized Rendering**: Minimal re-renders with React.memo
+- **Lazy Loading**: Code splitting for faster initial load
+- **Animation Throttling**: RequestAnimationFrame for smooth effects
+- **Mobile First**: Touch-optimized interactions
+
+## 📚 Educational Value
+
+SURVIV-OS teaches fundamental cybersecurity concepts including:
+
+- **Network Security**: Understanding IP addresses, ports, and protocols
+- **Threat Detection**: Identifying malicious activity patterns
+- **Defensive Strategies**: Configuring firewalls and access controls
+- **Ethical Hacking**: Using offensive tools responsibly
+- **Incident Response**: Reacting quickly to security breaches
+- **Resource Management**: Balancing security with performance
+- **Cryptography Basics**: Understanding encryption and decryption
+- **Binary & Protocols**: Converting between number systems
+- **Security Fundamentals**: Learning through contextual challenges
+
+Each game mechanic is designed to reinforce real-world security practices while remaining accessible to non-technical users. Knowledge is tested through gameplay actions rather than traditional quizzes - players learn by doing, solving, and overcoming challenges that directly impact their progress.
+
+## 🧪 Testing
+
+Run the test suite:
 ```bash
 npm test
 ```
 
-## Build for Production
-
+Run tests in watch mode:
+```bash
+npm test -- --watch
 ```
+
+Generate coverage report:
+```bash
+npm test -- --coverage
+```
+
+## 📦 Building for Production
+
+Create an optimized production build:
+```bash
 npm run build
 ```
 
-The production build outputs files in the `build/` directory and includes a service worker for offline support.
+The build outputs to the `build/` directory with:
+- Minified JavaScript and CSS
+- Optimized assets
+- Service worker for offline play
+- Source maps for debugging
+
+## 🤝 Contributing
+
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+
+### Development Workflow
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🎨 Credits
+
+- Game Design & Development: [Your Team]
+- Security Consultation: [Security Experts]
+- UI/UX Design: [Designers]
+- Sound Effects: [Audio Credits]
+
+## 🔗 Links
+
+- [Play Online](https://surviv-os.example.com)
+- [Documentation](https://docs.surviv-os.example.com)
+- [Discord Community](https://discord.gg/survivos)
+- [Bug Reports](https://github.com/yourusername/surviv-os/issues)
+
+---
+
+*SURVIV-OS: Learn Security. Survive the Wasteland. One Protocol at a Time.*

--- a/src/__tests__/CommunicatorScreen.test.jsx
+++ b/src/__tests__/CommunicatorScreen.test.jsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CommunicatorScreen from '../components/CommunicatorScreen';
+
+test('sends message and decrypts intercepted text', () => {
+  const { getByText, getByRole, getByTestId } = render(<CommunicatorScreen />);
+  const input = getByRole('textbox');
+  fireEvent.change(input, { target: { value: 'TEST' } });
+  fireEvent.click(getByText('Send'));
+  expect(getByTestId('message-log')).toHaveTextContent('TEST');
+
+  fireEvent.click(getByText('Decrypt'));
+  expect(getByText('This is a secret message')).toBeInTheDocument();
+});

--- a/src/__tests__/DecryptorScreen.test.jsx
+++ b/src/__tests__/DecryptorScreen.test.jsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DecryptorScreen from '../components/DecryptorScreen';
+
+test('decrypts caesar and base64', () => {
+  const { getByText, getByRole } = render(<DecryptorScreen />);
+  const textarea = getByRole('textbox');
+  fireEvent.change(textarea, { target: { value: 'KHOOR' } });
+  fireEvent.click(getByText('Decrypt'));
+  expect(getByText('HELLO')).toBeInTheDocument();
+
+  fireEvent.change(textarea, { target: { value: 'U1VSVklWRQ==' } });
+  fireEvent.change(getByRole('combobox'), { target: { value: 'base64' } });
+  fireEvent.click(getByText('Decrypt'));
+  expect(getByText('SURVIVE')).toBeInTheDocument();
+});

--- a/src/__tests__/DroneScreen.test.jsx
+++ b/src/__tests__/DroneScreen.test.jsx
@@ -1,0 +1,14 @@
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DroneScreen from '../components/DroneScreen';
+
+test('launching drone outputs scan log', () => {
+  jest.useFakeTimers();
+  const { getByText } = render(<DroneScreen />);
+  fireEvent.click(getByText('Launch Drone'));
+  act(() => {
+    jest.advanceTimersByTime(4000);
+  });
+  expect(getByText('Radiation spike detected')).toBeInTheDocument();
+  jest.useRealTimers();
+});

--- a/src/__tests__/HandbookScreen.test.jsx
+++ b/src/__tests__/HandbookScreen.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HandbookScreen from '../components/HandbookScreen';
+
+test('renders handbook sections', () => {
+  render(<HandbookScreen />);
+  expect(screen.getByText('Security Basics')).toBeInTheDocument();
+  expect(screen.getByText('Survival Tips')).toBeInTheDocument();
+});

--- a/src/__tests__/LogScreen.test.jsx
+++ b/src/__tests__/LogScreen.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LogScreen from '../components/LogScreen';
+
+test('displays intercepted logs', () => {
+  render(<LogScreen />);
+  expect(screen.getByText(/Encrypted ping/)).toBeInTheDocument();
+  expect(screen.getByText(/Distress call/)).toBeInTheDocument();
+});

--- a/src/__tests__/MapScreen.test.jsx
+++ b/src/__tests__/MapScreen.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MapScreen from '../components/MapScreen';
+
+test('renders map with location markers', () => {
+  const { getByTestId } = render(<MapScreen />);
+  const map = getByTestId('map-screen');
+  const markers = map.querySelectorAll('div.absolute');
+  expect(markers.length).toBe(4);
+});

--- a/src/__tests__/ScannerScreen.test.jsx
+++ b/src/__tests__/ScannerScreen.test.jsx
@@ -1,0 +1,15 @@
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScannerScreen from '../components/ScannerScreen';
+
+test('environment scan reveals results', () => {
+  jest.useFakeTimers();
+  const { getByText, container } = render(<ScannerScreen />);
+  fireEvent.click(getByText('Scan Environment'));
+  act(() => {
+    jest.advanceTimersByTime(3200);
+  });
+  const items = container.querySelectorAll('li');
+  expect(items.length).toBeGreaterThan(0);
+  jest.useRealTimers();
+});

--- a/src/__tests__/StatsScreen.test.jsx
+++ b/src/__tests__/StatsScreen.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StatsScreen from '../components/StatsScreen';
+
+test('shows world stats', () => {
+  render(<StatsScreen />);
+  expect(screen.getByText(/Radiation Levels/)).toBeInTheDocument();
+  expect(screen.getByText(/Threat Level/)).toBeInTheDocument();
+});

--- a/src/__tests__/TerminalScreen.test.jsx
+++ b/src/__tests__/TerminalScreen.test.jsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TerminalScreen from '../components/TerminalScreen';
+
+test('runs basic file commands', () => {
+  const { getByRole, getByText } = render(<TerminalScreen />);
+  const input = getByRole('textbox');
+  fireEvent.change(input, { target: { value: 'ls' } });
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  expect(getByText('home var')).toBeInTheDocument();
+
+  fireEvent.change(input, { target: { value: 'cd home' } });
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  fireEvent.change(input, { target: { value: 'ls' } });
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  expect(getByText('survivor.txt')).toBeInTheDocument();
+
+  fireEvent.change(input, { target: { value: 'cat survivor.txt' } });
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  expect(getByText(/Stay hidden/)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- update README with SURVIV-OS game overview
- add tests for communicator, decryptor, drone, handbook, log, map, scanner, stats and terminal screens

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851f7a293c483209dc47b0a420ef9ec