### PR TITLE
Implement full screen layout with matrix background

### DIFF
--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -25,7 +25,7 @@ const PhoneFrame = ({
 
   return (
     <div
-      className="relative w-full aspect-[9/16] border rounded-2xl overflow-hidden bg-black text-green-400 flex flex-col max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg"
+      className="relative w-full min-h-screen border overflow-hidden bg-black text-green-400 flex flex-col"
     >
       <div className={cn("flex items-center justify-between text-xs px-2 py-1", statusBarColor)}>
         <span>{time}</span>

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,10 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
   <React.StrictMode>
-    <App />
+    <div className="relative w-full min-h-screen overflow-hidden">
+      <div className="matrix-bg" />
+      <App />
+    </div>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- remove phone-like width restriction by updating `PhoneFrame`
- wrap app in `index.js` with matrix background and full-screen container

## Testing
- `CI=true npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6851f8e41e208320a8a5904c4185ee1e