### PR TITLE
Add tests for utils, templates, and registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 build/
+
+coverage/

--- a/src/__tests__/appRegistry.test.js
+++ b/src/__tests__/appRegistry.test.js
@@ -1,0 +1,29 @@
+import { appRegistry } from '../lib/appRegistry';
+
+test('includes communicator app with required fields', () => {
+  const app = appRegistry.communicator;
+  expect(app).toMatchObject({
+    id: 'communicator',
+    category: 'apps',
+    isLocked: false,
+    launchScreen: 'CommunicatorScreen',
+  });
+  expect(Array.isArray(app.unlockRequirements)).toBe(true);
+});
+
+test('all apps have required properties', () => {
+  Object.values(appRegistry).forEach(app => {
+    expect(app).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: expect.any(String),
+        icon: expect.any(String),
+        category: expect.any(String),
+        isLocked: expect.any(Boolean),
+        unlockRequirements: expect.any(Array),
+        description: expect.any(String),
+        launchScreen: expect.any(String),
+      })
+    );
+  });
+});

--- a/src/__tests__/scriptTemplates.test.js
+++ b/src/__tests__/scriptTemplates.test.js
@@ -1,0 +1,22 @@
+import { scriptTemplates } from '../lib/scriptTemplates';
+
+test('basicScan template starts with START and ends with END', () => {
+  const tmpl = scriptTemplates.basicScan;
+  expect(tmpl[0].type).toBe('START');
+  expect(tmpl[tmpl.length - 1].type).toBe('END');
+});
+
+test('all templates have required block fields', () => {
+  Object.values(scriptTemplates).forEach(template => {
+    template.forEach(block => {
+      expect(block).toEqual(
+        expect.objectContaining({
+          type: expect.any(String),
+          x: expect.any(Number),
+          y: expect.any(Number),
+          parameters: expect.any(Object),
+        })
+      );
+    });
+  });
+});

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,0 +1,9 @@
+import { cn } from '../lib/utils';
+
+test('joins class names', () => {
+  expect(cn('foo', 'bar')).toBe('foo bar');
+});
+
+test('later classes override earlier ones', () => {
+  expect(cn('p-2', 'p-4')).toBe('p-4');
+});


### PR DESCRIPTION
## Summary
- add unit tests for app registry structure
- cover script templates with a new test suite
- test the `cn` utility function
- ignore coverage folder

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6851fb518ba88320b8886c128378edf2