### PR TITLE
Fix script execution visualizer props

### DIFF
--- a/src/__tests__/ExecutionVisualizer.test.jsx
+++ b/src/__tests__/ExecutionVisualizer.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ExecutionVisualizer from '../components/scriptbuilder/ExecutionVisualizer';
+
+test('runs through commands and triggers completion', () => {
+  jest.useFakeTimers();
+  const handleComplete = jest.fn();
+  render(
+    <ExecutionVisualizer
+      commands={[{ type: 'init' }, { type: 'end' }]}
+      onComplete={handleComplete}
+    />,
+  );
+
+  // First command highlighted after 300ms
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+  expect(screen.getByText('init')).toHaveClass('text-black');
+
+  // Second command highlighted after 600ms
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+  expect(screen.getByText('end')).toHaveClass('text-black');
+
+  // Completion callback after final step
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+  expect(handleComplete).toHaveBeenCalled();
+  jest.useRealTimers();
+});

--- a/src/components/scriptbuilder/ExecutionVisualizer.jsx
+++ b/src/components/scriptbuilder/ExecutionVisualizer.jsx
@@ -41,7 +41,12 @@ const ExecutionVisualizer = ({ commands, onComplete }) => {
 };
 
 ExecutionVisualizer.propTypes = {
-  commands: PropTypes.arrayOf(PropTypes.string).isRequired,
+  commands: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({ type: PropTypes.string.isRequired }),
+    ]),
+  ).isRequired,
   onComplete: PropTypes.func,
 };
 


### PR DESCRIPTION
## Summary
- improve `ExecutionVisualizer` prop types to handle object commands
- add a new unit test covering `ExecutionVisualizer`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851fcfd7e1c8320a86981bdd70507dd