### PR TITLE
Improve gameplay interactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,13 +40,21 @@ const App = () => {
 
   const [phoneState] = usePhoneState();
   const [currentApp, setCurrentApp] = useState(null);
+  const [appProps, setAppProps] = useState({});
+  const [animating, setAnimating] = useState(false);
 
-  const handleLaunchApp = (appId) => {
+  const handleLaunchApp = (appId, props = {}) => {
+    setAnimating(true);
     setCurrentApp(appId);
+    setAppProps(props);
+    setTimeout(() => setAnimating(false), 300);
   };
 
   const handleBack = () => {
+    setAnimating(true);
     setCurrentApp(null);
+    setAppProps({});
+    setTimeout(() => setAnimating(false), 300);
   };
 
   const Active = currentApp ? appComponents[currentApp] : null;
@@ -57,20 +65,39 @@ const App = () => {
       networkStrength={phoneState.networkStrength}
       threatLevel={phoneState.activeThreats.length}
     >
-      {!Active && <HomeScreen onLaunchApp={handleLaunchApp} />}
-      {Active && (
-        <div className="flex flex-col h-full" data-testid="active-app">
-          <button
-            type="button"
-            onClick={handleBack}
-            className="m-2 px-2 py-1 border border-green-500 text-green-400 rounded"
-            data-testid="back-button"
-          >
-            Back
-          </button>
-          <Active practice={practiceMode} />
+      <div className="relative h-full overflow-hidden">
+        <div
+          className={`absolute inset-0 transition-transform duration-300 ${
+            currentApp ? '-translate-x-full' : 'translate-x-0'
+          } ${animating ? '' : ''}`}
+        >
+          <HomeScreen onLaunchApp={handleLaunchApp} />
         </div>
-      )}
+        {Active && (
+          <div
+            className={`absolute inset-0 transition-transform duration-300 ${
+              currentApp ? 'translate-x-0' : 'translate-x-full'
+            } ${animating ? '' : ''}`}
+            data-testid="active-app"
+          >
+            <div className="flex flex-col h-full">
+              <button
+                type="button"
+                onClick={handleBack}
+                className="m-2 px-2 py-1 border border-green-500 text-green-400 rounded"
+                data-testid="back-button"
+              >
+                Back
+              </button>
+              <Active
+                practice={practiceMode}
+                onLaunchApp={handleLaunchApp}
+                {...appProps}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </PhoneFrame>
   );
 };

--- a/src/__tests__/NetworkScanner.test.jsx
+++ b/src/__tests__/NetworkScanner.test.jsx
@@ -46,3 +46,38 @@ test('resources allocated during scan are released', () => {
   expect(getUsage().cpu).toBe(0);
   jest.useRealTimers();
 });
+
+test('attack launches port scanner with ip', () => {
+  jest.useFakeTimers();
+  const handleLaunch = jest.fn();
+  render(<NetworkScanner onLaunchApp={handleLaunch} />);
+  fireEvent.click(screen.getByText('Scan'));
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  fireEvent.click(screen.getByTestId('bad-device'));
+  const ip = screen.getByText(/IP:/i).textContent.replace('IP: ', '');
+  fireEvent.click(screen.getByText('Attack'));
+  expect(handleLaunch).toHaveBeenCalledWith('portScanner', {
+    initialTarget: ip,
+  });
+  jest.useRealTimers();
+});
+
+test('connect launches terminal with ip', () => {
+  jest.useFakeTimers();
+  const handleLaunch = jest.fn();
+  render(<NetworkScanner onLaunchApp={handleLaunch} />);
+  fireEvent.click(screen.getByText('Scan'));
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  const device = screen.getAllByTestId('device')[0];
+  fireEvent.click(device);
+  const ip = screen.getByText(/IP:/i).textContent.replace('IP: ', '');
+  fireEvent.click(screen.getByText('Connect'));
+  expect(handleLaunch).toHaveBeenCalledWith('terminal', {
+    initialCommand: `connect ${ip}`,
+  });
+  jest.useRealTimers();
+});

--- a/src/__tests__/TerminalScreen.test.jsx
+++ b/src/__tests__/TerminalScreen.test.jsx
@@ -19,3 +19,8 @@ test('runs basic file commands', () => {
   fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
   expect(getByText(/Stay hidden/)).toBeInTheDocument();
 });
+
+test('initial command prefills input', () => {
+  const { getByDisplayValue } = render(<TerminalScreen initialCommand="ping 1.2.3.4" />);
+  expect(getByDisplayValue('ping 1.2.3.4')).toBeInTheDocument();
+});

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -175,7 +175,7 @@ const ApocalypseGame = ({ practice = false }) => {
         activeAttack: attack,
         message: `[ WARNING ] ${attack.message}`,
       }));
-    }, Math.random() * 15000 + 10000);
+    }, Math.random() * 5000 + 5000);
     return () => clearTimeout(timeout);
   }, [practice, gameState.bootUp, gameState.gameCompleted, gameState.activeAttack]);
 

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -115,7 +115,7 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
     SecurityTrainingApp,
   };
 
-  const launchApp = (appId) => {
+  const launchApp = (appId, props = {}) => {
     const def = appRegistry[appId];
     if (!def) return;
     const locked = def.isLocked && !phoneState.unlockedApps.includes(appId);
@@ -126,7 +126,7 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
     }
     setLockMessage('');
     if (onLaunchApp) {
-      onLaunchApp(appId);
+      onLaunchApp(appId, props);
     } else {
       setActiveApp(appId);
       setPhoneState((s) => ({ ...s, currentScreen: 'active-app' }));

--- a/src/components/NetworkScanner.jsx
+++ b/src/components/NetworkScanner.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import {
   allocateResources,
   freeResources,
@@ -28,10 +29,11 @@ function generateDevices() {
   return devices;
 }
 
-const NetworkScanner = () => {
+const NetworkScanner = ({ onLaunchApp }) => {
   const [devices, setDevices] = useState([]);
   const [scanning, setScanning] = useState(false);
   const [selected, setSelected] = useState(null);
+  const [actionMsg, setActionMsg] = useState('');
   const [progress, setProgress] = useState(0);
   const timerRef = useRef(null);
   const intervalRef = useRef(null);
@@ -58,6 +60,21 @@ const NetworkScanner = () => {
       clearInterval(intervalRef.current);
       freeResources('scanner');
     }, 3000);
+  };
+
+  const handleAction = () => {
+    if (!selected) return;
+    if (selected.isBad) {
+      setActionMsg(`Attacking ${selected.ip}...`);
+      if (onLaunchApp) {
+        onLaunchApp('portScanner', { initialTarget: selected.ip });
+      }
+    } else {
+      setActionMsg(`Connecting to ${selected.ip}...`);
+      if (onLaunchApp) {
+        onLaunchApp('terminal', { initialCommand: `connect ${selected.ip}` });
+      }
+    }
   };
 
   return (
@@ -93,15 +110,26 @@ const NetworkScanner = () => {
         {scanning ? 'Scanning...' : 'Scan'}
       </button>
       {selected && (
-        <div className="text-green-400 border border-green-500 rounded p-2">
+        <div className="text-green-400 border border-green-500 rounded p-2 space-y-2">
           <div>IP: {selected.ip}</div>
           <div>Type: {selected.type}</div>
           <div>Vulnerability: {selected.vulnerability}</div>
           {selected.isBad && <div className="text-red-400">TARGET DEVICE</div>}
+          <button
+            onClick={handleAction}
+            className="mt-2 border border-green-500 rounded px-2 py-1"
+          >
+            {selected.isBad ? 'Attack' : 'Connect'}
+          </button>
+          {actionMsg && <div className="text-xs">{actionMsg}</div>}
         </div>
       )}
     </div>
   );
+};
+
+NetworkScanner.propTypes = {
+  onLaunchApp: PropTypes.func,
 };
 
 export default NetworkScanner;

--- a/src/components/TerminalScreen.jsx
+++ b/src/components/TerminalScreen.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Minimal command-line interface supporting a few demo commands.
@@ -12,10 +13,14 @@ const readFile = {
   'survivor.txt': 'Stay hidden. Avoid radiation. Keep moving.',
 };
 
-const TerminalScreen = () => {
+const TerminalScreen = ({ initialCommand = '' }) => {
   const [cwd, setCwd] = useState('/');
   const [history, setHistory] = useState([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState(initialCommand);
+
+  useEffect(() => {
+    setInput(initialCommand);
+  }, [initialCommand]);
 
   const run = () => {
     const parts = input.trim().split(' ');
@@ -54,6 +59,10 @@ const TerminalScreen = () => {
       </div>
     </div>
   );
+};
+
+TerminalScreen.propTypes = {
+  initialCommand: PropTypes.string,
 };
 
 export default TerminalScreen;


### PR DESCRIPTION
## Summary
- allow apps to launch other tools by providing props
- prefill TerminalScreen input when a command is provided
- make NetworkScanner open PortScanner or Terminal with device IP
- cover new behaviour with tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68522982a54c8320b40532cae12d95d7