### PR TITLE
Add tutorial manager and missions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import HandbookScreen from './components/HandbookScreen';
 import StatsScreen from './components/StatsScreen';
 import LogScreen from './components/LogScreen';
 import SecurityTrainingApp from './components/SecurityTrainingApp';
+import { TutorialProvider } from "./hooks/useTutorial";
 import usePhoneState from './hooks/usePhoneState';
 
 const appComponents = {
@@ -59,7 +60,8 @@ const App = () => {
 
   const Active = currentApp ? appComponents[currentApp] : null;
 
-  return (
+  return (<TutorialProvider>
+  
     <PhoneFrame
       batteryLevel={phoneState.batteryLevel}
       networkStrength={phoneState.networkStrength}
@@ -99,7 +101,8 @@ const App = () => {
         )}
       </div>
     </PhoneFrame>
-  );
+  </TutorialProvider>
+);
 };
 
 export default App;

--- a/src/__tests__/tutorialSystem.test.js
+++ b/src/__tests__/tutorialSystem.test.js
@@ -1,0 +1,24 @@
+import { loadProgress, saveProgress, resetProgress, tutorialMissions } from '../lib/tutorialSystem';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('saves and loads progress', () => {
+  saveProgress({ completed: ['firstBoot'], activeMission: 'threatDefense' });
+  const data = loadProgress();
+  expect(data).toEqual({ completed: ['firstBoot'], activeMission: 'threatDefense' });
+});
+
+test('resetProgress clears data', () => {
+  saveProgress({ completed: [], activeMission: 'firstBoot' });
+  resetProgress();
+  expect(loadProgress()).toEqual({ completed: [], activeMission: null });
+});
+
+// ensure missions list includes expected ids
+test('tutorial missions defined', () => {
+  const ids = tutorialMissions.map((m) => m.id);
+  expect(ids).toContain('firstBoot');
+  expect(ids).toContain('threatDefense');
+});

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -30,7 +30,7 @@ const AppIcon = ({
   };
 
   return (
-    <div className="flex flex-col items-center w-16">
+    <div id={`app-icon-${appId}`} className="flex flex-col items-center w-16">
       <div
         draggable={isDraggable && !isLocked}
         onDragStart={handleDragStart}

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -164,15 +164,15 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
         onChange={(e) => setSearch(e.target.value)}
         placeholder="Search"
         className="w-full px-2 py-1 rounded bg-gray-800 text-green-400"
-        data-testid="search-bar"
+        id="search-input" data-testid="search-bar"
       />
-      <div className="text-xs text-green-400 flex justify-around border border-gray-700 rounded p-1" data-testid="status-widgets">
+      <div className="text-xs text-green-400 flex justify-around border border-gray-700 rounded p-1" id="status-widgets" data-testid="status-widgets">
         <div>CPU {usage.cpu}%</div>
         <div>RAM {usage.ram}%</div>
         <div>BW {usage.bandwidth}%</div>
       </div>
       <div className="flex-1 overflow-auto">
-        <div className="grid grid-cols-4 gap-2" data-testid="app-grid">
+        <div className="grid grid-cols-4 gap-2" id="app-grid" data-testid="app-grid">
           {gridSlots.map((appId, i) => {
             const def = appRegistry[appId];
             const Icon = def ? Icons[def.icon] : null;

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -38,7 +38,7 @@ const PhoneFrame = ({
             <Wifi className="w-4 h-4" />
             <span>{networkStrength}</span>
           </div>
-          <div className="flex items-center space-x-1">
+          <div id="threat-indicator" className="flex items-center space-x-1">
             <Shield className="w-4 h-4" />
             <span>{threatLevel}</span>
           </div>

--- a/src/hooks/useTutorial.js
+++ b/src/hooks/useTutorial.js
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import TutorialOverlay from '../components/TutorialOverlay';
+import { tutorialMissions, loadProgress, saveProgress } from '../lib/tutorialSystem';
+
+const TutorialContext = createContext(null);
+
+export const TutorialProvider = ({ children }) => {
+  const [state, setState] = useState(() => loadProgress());
+  const [helpSteps, setHelpSteps] = useState(null);
+
+  useEffect(() => {
+    saveProgress(state);
+  }, [state]);
+
+  const startMission = (id) => {
+    setState({ ...state, activeMission: id });
+  };
+
+  const skipTutorial = () => {
+    setState({ completed: tutorialMissions.map((m) => m.id), activeMission: null });
+  };
+
+  const resume = () => {
+    if (state.activeMission) return;
+    const next = tutorialMissions.find((m) => !state.completed.includes(m.id));
+    if (next) setState({ ...state, activeMission: next.id });
+  };
+
+  const showHelp = (targetId, message) => {
+    setHelpSteps([{ targetId, message, action: 'click' }]);
+  };
+
+  const activeMission = tutorialMissions.find((m) => m.id === state.activeMission);
+
+  const handleMissionComplete = () => {
+    setState((prev) => ({
+      completed: [...prev.completed, prev.activeMission],
+      activeMission: null,
+    }));
+  };
+
+  return (
+    <TutorialContext.Provider value={{ ...state, startMission, skipTutorial, resume, showHelp }}>
+      {children}
+      {activeMission && (
+        <TutorialOverlay key={activeMission.id} steps={activeMission.steps} onComplete={handleMissionComplete} />
+      )}
+      {helpSteps && !activeMission && (
+        <TutorialOverlay key="help" steps={helpSteps} onComplete={() => setHelpSteps(null)} />
+      )}
+    </TutorialContext.Provider>
+  );
+};
+
+export const useTutorial = () => useContext(TutorialContext);

--- a/src/lib/tutorialSystem.js
+++ b/src/lib/tutorialSystem.js
@@ -1,0 +1,76 @@
+const STORAGE_KEY = 'survivos-tutorial';
+
+export const tutorialMissions = [
+  {
+    id: 'firstBoot',
+    name: 'First Boot',
+    steps: [
+      {
+        targetId: 'search-input',
+        message: 'This is your app search. Locate tools quickly.',
+        action: 'focus',
+      },
+      {
+        targetId: 'app-grid',
+        message: 'Tap an app icon to open it.',
+        action: 'click',
+      },
+    ],
+  },
+  {
+    id: 'threatDefense',
+    name: 'Threat Defense 101',
+    steps: [
+      {
+        targetId: 'threat-indicator',
+        message: 'Watch for incoming attacks here.',
+        action: 'click',
+      },
+      {
+        targetId: 'app-icon-firewall',
+        message: 'Launch the Firewall to repel threats.',
+        action: 'click',
+      },
+    ],
+  },
+  {
+    id: 'appMastery',
+    name: 'App Mastery',
+    steps: [
+      {
+        targetId: 'app-icon-scriptBuilder',
+        message: 'Drag blocks to build scripts.',
+        action: 'click',
+      },
+    ],
+  },
+  {
+    id: 'resourceMgmt',
+    name: 'Resource Management',
+    steps: [
+      {
+        targetId: 'status-widgets',
+        message: 'Monitor CPU, RAM and bandwidth here.',
+        action: 'click',
+      },
+    ],
+  },
+];
+
+export function loadProgress() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return { completed: [], activeMission: null };
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { completed: [], activeMission: null };
+  }
+}
+
+export function saveProgress(state) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function resetProgress() {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- create tutorial system library with mission data
- add hook and provider for tutorial progress with overlay integration
- instrument phone UI with IDs for tutorial steps
- wrap main app with TutorialProvider
- test tutorial system logic

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68523eb4948483209d655b0a9c97b289