### PR TITLE
Add regression tests for invalid save state

### DIFF
--- a/src/__tests__/saveSystem.test.js
+++ b/src/__tests__/saveSystem.test.js
@@ -20,3 +20,8 @@ test('resetGame clears saved data', () => {
   resetGame();
   expect(loadGame()).toBeNull();
 });
+
+test('loadGame returns null for invalid JSON', () => {
+  localStorage.setItem('survivos-save', '{bad json');
+  expect(loadGame()).toBeNull();
+});

--- a/src/__tests__/usePhoneState.test.jsx
+++ b/src/__tests__/usePhoneState.test.jsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import usePhoneState, { initialPhoneState } from '../hooks/usePhoneState';
+
+function TestComponent() {
+  const [state] = usePhoneState();
+  return <div data-testid="screen">{state.currentScreen}</div>;
+}
+
+test('usePhoneState falls back to defaults with invalid save data', () => {
+  localStorage.setItem('survivos-save', '{bad json');
+  const { getByTestId } = render(<TestComponent />);
+  expect(getByTestId('screen').textContent).toBe(initialPhoneState.currentScreen);
+});


### PR DESCRIPTION
## Summary
- add safeguard tests for bad save data
- ensure `usePhoneState` handles corrupted localStorage

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6852385003388320923c0d86cf72e41b