### PR TITLE
Add tests for installed apps persistence

### DIFF
--- a/src/__tests__/saveSystem.test.js
+++ b/src/__tests__/saveSystem.test.js
@@ -20,3 +20,32 @@ test('resetGame clears saved data', () => {
   resetGame();
   expect(loadGame()).toBeNull();
 });
+
+test('loadGame returns null for invalid JSON', () => {
+  localStorage.setItem('survivos-save', '{bad json');
+  expect(loadGame()).toBeNull();
+});
+
+test('loadGame returns null for mismatched version', () => {
+  localStorage.setItem(
+    'survivos-save',
+    JSON.stringify({ version: 2, currentScreen: 'home', unlockedApps: [], completedMissions: [] })
+  );
+  expect(loadGame()).toBeNull();
+});
+
+test('loadGame returns null when fields are missing', () => {
+  localStorage.setItem('survivos-save', JSON.stringify({ version: 1 }));
+  expect(loadGame()).toBeNull();
+});
+
+test('saveGame persists installedApps', () => {
+  saveGame({
+    currentScreen: 'home',
+    unlockedApps: [],
+    completedMissions: [],
+    installedApps: ['scanner'],
+  });
+  const data = loadGame();
+  expect(data.installedApps).toEqual(['scanner']);
+});

--- a/src/__tests__/usePhoneState.test.jsx
+++ b/src/__tests__/usePhoneState.test.jsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import usePhoneState, { initialPhoneState } from '../hooks/usePhoneState';
+
+function TestComponent() {
+  const [state] = usePhoneState();
+  return <div data-testid="screen">{state.currentScreen}</div>;
+}
+
+test('usePhoneState falls back to defaults with invalid save data', () => {
+  localStorage.setItem('survivos-save', '{bad json');
+  const { getByTestId } = render(<TestComponent />);
+  expect(getByTestId('screen').textContent).toBe(initialPhoneState.currentScreen);
+});

--- a/src/lib/saveSystem.js
+++ b/src/lib/saveSystem.js
@@ -12,6 +12,7 @@ export function saveGame(state) {
     currentScreen: state.currentScreen,
     unlockedApps: state.unlockedApps || [],
     completedMissions: state.completedMissions || [],
+    installedApps: state.installedApps || [],
   };
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
@@ -29,7 +30,21 @@ export function loadGame() {
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw);
-    return parsed;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      parsed.version !== VERSION ||
+      typeof parsed.currentScreen !== 'string' ||
+      !Array.isArray(parsed.unlockedApps) ||
+      !Array.isArray(parsed.completedMissions) ||
+      (parsed.installedApps && !Array.isArray(parsed.installedApps))
+    ) {
+      return null;
+    }
+    return {
+      ...parsed,
+      installedApps: parsed.installedApps || [],
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- save and load installed apps in saveSystem
- test installed apps persistence in saveSystem

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6852385003388320923c0d86cf72e41b