### PR TITLE
Add configurable Settings app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import HandbookScreen from './components/HandbookScreen';
 import StatsScreen from './components/StatsScreen';
 import LogScreen from './components/LogScreen';
 import SecurityTrainingApp from './components/SecurityTrainingApp';
+import SettingsScreen from './components/SettingsScreen';
 import { TutorialProvider } from "./hooks/useTutorial";
 import usePhoneState from './hooks/usePhoneState';
 
@@ -33,6 +34,7 @@ const appComponents = {
   networkScanner: NetworkScanner,
   portScanner: PortScanner,
   firewall: FirewallApp,
+  settings: SettingsScreen,
 };
 
 const App = () => {

--- a/src/__tests__/SettingsScreen.test.jsx
+++ b/src/__tests__/SettingsScreen.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SettingsScreen from '../components/SettingsScreen';
+
+test('renders settings sections', () => {
+  render(<SettingsScreen />);
+  expect(screen.getByText('Audio')).toBeInTheDocument();
+  expect(screen.getByText('Display')).toBeInTheDocument();
+  expect(screen.getByText('Gameplay')).toBeInTheDocument();
+  expect(screen.getByText('Data Management')).toBeInTheDocument();
+});
+

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -21,6 +21,7 @@ import NetworkScanner from './NetworkScanner';
 import PortScanner from './PortScanner';
 import FirewallApp from './FirewallApp';
 import SecurityTrainingApp from './SecurityTrainingApp';
+import SettingsScreen from './SettingsScreen';
 
 const GRID_KEY = 'homeGridSlots';
 
@@ -113,6 +114,7 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
     PortScanner,
     FirewallApp,
     SecurityTrainingApp,
+    SettingsScreen,
   };
 
   const launchApp = (appId, props = {}) => {

--- a/src/components/SettingsScreen.jsx
+++ b/src/components/SettingsScreen.jsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'survivos-settings';
+
+const defaultSettings = {
+  audio: {
+    masterVolume: 1,
+    musicVolume: 0.7,
+    sfxVolume: 0.7,
+    muted: false,
+  },
+  display: {
+    brightness: 100,
+    highContrast: false,
+    reduceMotion: false,
+    fontSize: 16,
+  },
+  gameplay: {
+    difficulty: 'Normal',
+    hints: true,
+    autosaveInterval: 30000,
+    practiceMode: false,
+  },
+};
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultSettings;
+    const parsed = JSON.parse(raw);
+    return { ...defaultSettings, ...parsed };
+  } catch {
+    return defaultSettings;
+  }
+}
+
+function saveSettings(s) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+  } catch {
+    /* ignore */
+  }
+}
+
+const Slider = ({ label, value, onChange, min = 0, max = 1, step = 0.01 }) => (
+  <label className="flex items-center space-x-2">
+    <span className="w-32">{label}</span>
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onChange(parseFloat(e.target.value))}
+      className="flex-1"
+    />
+    <span className="w-8 text-right">{Math.round(value * 100)}</span>
+  </label>
+);
+
+const SettingsScreen = () => {
+  const [settings, setSettings] = useState(loadSettings);
+
+  useEffect(() => {
+    saveSettings(settings);
+    document.documentElement.style.filter = `brightness(${settings.display.brightness}%)`;
+    document.documentElement.style.fontSize = `${settings.display.fontSize}px`;
+    document.body.classList.toggle('high-contrast', settings.display.highContrast);
+    document.body.classList.toggle('reduce-motion', settings.display.reduceMotion);
+  }, [settings]);
+
+  const update = (path, value) => {
+    setSettings((s) => {
+      const updated = { ...s };
+      let obj = updated;
+      for (let i = 0; i < path.length - 1; i++) obj = obj[path[i]];
+      obj[path[path.length - 1]] = value;
+      return { ...updated };
+    });
+  };
+
+  const exportData = () => {
+    const save = localStorage.getItem('survivos-save');
+    const blob = new Blob([save || '{}'], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'survivos-save.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importData = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        localStorage.setItem('survivos-save', reader.result);
+        alert('Progress imported');
+      } catch {
+        alert('Import failed');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const resetData = () => {
+    if (window.confirm('Erase all save data?')) {
+      localStorage.removeItem('survivos-save');
+      alert('Data reset');
+    }
+  };
+
+  const save = localStorage.getItem('survivos-save') || '{}';
+
+  return (
+    <div className="p-4 space-y-4 text-green-400 bg-black font-mono" data-testid="settings-screen">
+      <h2 className="text-xl">Settings</h2>
+
+      <section className="space-y-2">
+        <h3 className="text-lg">Audio</h3>
+        <Slider label="Master" value={settings.audio.masterVolume} onChange={(v) => update(['audio','masterVolume'], v)} />
+        <Slider label="Music" value={settings.audio.musicVolume} onChange={(v) => update(['audio','musicVolume'], v)} />
+        <Slider label="SFX" value={settings.audio.sfxVolume} onChange={(v) => update(['audio','sfxVolume'], v)} />
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={settings.audio.muted} onChange={(e) => update(['audio','muted'], e.target.checked)} />
+          <span>Mute</span>
+        </label>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-lg">Display</h3>
+        <Slider label="Brightness" min={50} max={150} step={1} value={settings.display.brightness} onChange={(v) => update(['display','brightness'], v)} />
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={settings.display.highContrast} onChange={(e) => update(['display','highContrast'], e.target.checked)} />
+          <span>High Contrast</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={settings.display.reduceMotion} onChange={(e) => update(['display','reduceMotion'], e.target.checked)} />
+          <span>Reduce Motion</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <span className="w-32">Font Size</span>
+          <input type="number" className="w-16 bg-black border border-green-500" value={settings.display.fontSize} onChange={(e) => update(['display','fontSize'], parseInt(e.target.value,10))} />
+        </label>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-lg">Gameplay</h3>
+        <label className="flex items-center space-x-2">
+          <span className="w-32">Difficulty</span>
+          <select className="bg-black border border-green-500" value={settings.gameplay.difficulty} onChange={(e) => update(['gameplay','difficulty'], e.target.value)}>
+            <option>Easy</option>
+            <option>Normal</option>
+            <option>Hard</option>
+            <option>Survivor</option>
+          </select>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={settings.gameplay.hints} onChange={(e) => update(['gameplay','hints'], e.target.checked)} />
+          <span>Hints</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <span className="w-32">Auto-save (s)</span>
+          <input type="number" className="w-20 bg-black border border-green-500" value={settings.gameplay.autosaveInterval} onChange={(e) => update(['gameplay','autosaveInterval'], parseInt(e.target.value,10))} />
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={settings.gameplay.practiceMode} onChange={(e) => update(['gameplay','practiceMode'], e.target.checked)} />
+          <span>Practice Mode</span>
+        </label>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-lg">Data Management</h3>
+        <pre className="overflow-auto border border-green-500 p-2 text-xs max-h-32">{save}</pre>
+        <button onClick={exportData} className="px-2 py-1 border border-green-500">Export</button>
+        <input type="file" accept="application/json" onChange={importData} className="block" />
+        <button onClick={resetData} className="px-2 py-1 border border-red-500 text-red-400">Reset Data</button>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-lg">About</h3>
+        <div>Game Version: 1.0.0</div>
+        <div>See README for credits.</div>
+        <a href="https://github.com/kingpinzs/post-apoc-learn" className="underline">Documentation</a>
+        <button className="px-2 py-1 border border-green-500" onClick={() => window.open('https://github.com/kingpinzs/post-apoc-learn/issues/new')}>Report Bug</button>
+      </section>
+    </div>
+  );
+};
+
+export default SettingsScreen;
+

--- a/src/index.css
+++ b/src/index.css
@@ -122,3 +122,13 @@
   0% { transform: translate(0,0); }
   100% { transform: translate(-50%, -50%); }
 }
+
+body.high-contrast {
+  filter: contrast(2);
+}
+
+body.reduce-motion * {
+  animation-duration: 0s !important;
+  transition-duration: 0s !important;
+}
+

--- a/src/lib/appRegistry.js
+++ b/src/lib/appRegistry.js
@@ -159,4 +159,14 @@ export const appRegistry = {
     description: 'Configure firewall rules.',
     launchScreen: 'FirewallApp',
   },
+  settings: {
+    id: 'settings',
+    name: 'Settings',
+    icon: 'Settings',
+    category: 'info',
+    isLocked: false,
+    unlockRequirements: [],
+    description: 'Configure audio, display, and gameplay options.',
+    launchScreen: 'SettingsScreen',
+  },
 };


### PR DESCRIPTION
## Summary
- create `SettingsScreen` component
- register settings app in the app registry and screen maps
- expose options for audio, display, gameplay, data management, and about info
- add high contrast and reduced motion styles
- include unit test for the new settings screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852446572e4832093d9d330218080e6