### PR TITLE
Add testing suite and CI improvements

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,21 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run unit tests
+        run: npm test -- --watchAll=false --coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          start: npm start
+          wait-on: 'http://localhost:3000'
+
       - name: Build React App
         run: npm run build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 build/
 
 coverage/
+cypress/screenshots/
+cypress/videos/

--- a/README.md
+++ b/README.md
@@ -232,15 +232,16 @@ Run the test suite:
 npm test
 ```
 
-Run tests in watch mode:
+Generate a coverage report:
 ```bash
-npm test -- --watch
+npm run coverage
 ```
 
-Generate coverage report:
+Run Cypress end-to-end tests:
 ```bash
-npm test -- --coverage
+npm run e2e
 ```
+
 
 ## 📦 Building for Production
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: false,
+  },
+});

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -1,0 +1,6 @@
+describe('SURVIV-OS', () => {
+  it('loads the home page', () => {
+    cy.visit('/');
+    cy.contains('INITIATE HACK');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
         "start": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
+        "coverage": "react-scripts test --coverage --watchAll=false",
+        "e2e": "cypress run",
         "eject": "react-scripts eject",
         "predeploy": "npm run build",
         "deploy": "gh-pages -d build"
@@ -47,6 +49,8 @@
     },
     "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "gh-pages": "^6.3.0"
+        "gh-pages": "^6.3.0",
+        "cypress": "^13.7.0",
+        "http-server": "^14.1.1"
     }
 }

--- a/src/__tests__/GameCleanup.test.jsx
+++ b/src/__tests__/GameCleanup.test.jsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ApocalypseGame from '../components/Game';
+
+describe('ApocalypseGame cleanup', () => {
+  test('removes keydown listener on unmount', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<ApocalypseGame practice />);
+    expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+});

--- a/src/__tests__/autoSave.test.js
+++ b/src/__tests__/autoSave.test.js
@@ -1,0 +1,23 @@
+import { startAutoSave, resetGame } from '../lib/saveSystem';
+
+describe('startAutoSave', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('saves at interval and stops after cleanup', () => {
+    const spy = jest.spyOn(Storage.prototype, 'setItem');
+    const stop = startAutoSave(() => ({ currentScreen: 'home', unlockedApps: [], completedMissions: [] }), 1000);
+    jest.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalled();
+    spy.mockClear();
+    stop();
+    jest.advanceTimersByTime(1000);
+    expect(spy).not.toHaveBeenCalled();
+    resetGame();
+  });
+});

--- a/src/__tests__/performance.test.js
+++ b/src/__tests__/performance.test.js
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import App from '../App';
+
+describe('render performance', () => {
+  test('App renders quickly', () => {
+    const start = performance.now();
+    render(<App />);
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(200);
+  });
+});

--- a/src/__tests__/useTutorial.test.jsx
+++ b/src/__tests__/useTutorial.test.jsx
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TutorialProvider, useTutorial } from '../hooks/useTutorial';
+import { tutorialMissions } from '../lib/tutorialSystem';
+import React from 'react';
+
+describe('useTutorial hook', () => {
+  test('resume starts first incomplete mission', () => {
+    const wrapper = ({ children }) => <TutorialProvider>{children}</TutorialProvider>;
+    const { result } = renderHook(() => useTutorial(), { wrapper });
+    act(() => result.current.resume());
+    expect(result.current.activeMission).toBe(tutorialMissions[0].id);
+  });
+
+  test('skipTutorial marks all missions complete', () => {
+    const wrapper = ({ children }) => <TutorialProvider>{children}</TutorialProvider>;
+    const { result } = renderHook(() => useTutorial(), { wrapper });
+    act(() => result.current.skipTutorial());
+    expect(result.current.completed).toEqual(tutorialMissions.map(m => m.id));
+  });
+
+  test('showHelp displays tutorial overlay', () => {
+    const Test = () => {
+      const { showHelp } = useTutorial();
+      React.useEffect(() => {
+        showHelp('target', 'Help message');
+      }, [showHelp]);
+      return <button id="target">Target</button>;
+    };
+    render(
+      <TutorialProvider>
+        <Test />
+      </TutorialProvider>
+    );
+    expect(screen.getByText('Help message')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- update README with coverage and e2e commands
- add coverage/e2e scripts and dev dependencies
- configure cypress for e2e tests
- extend workflow to run tests and cypress
- ignore cypress artifacts
- add unit tests for useTutorial and save system auto-save
- add cleanup and performance tests

## Testing
- `CI=true npm test -- --watchAll=false --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6852460fbd80832091464a238b28731f