### PR TITLE
Add offline mode features

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ The build outputs to the `build/` directory with:
 - Service worker for offline play
 - Source maps for debugging
 
+## Offline Mode
+
+SURVIV-OS now monitors network connectivity and caches assets for offline play.
+Actions performed while offline are queued and synced once a connection is
+restored. When a new version of the game is available, you'll be notified to
+reload.
+
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,9 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
 
+const { registerRoute } = workbox.routing;
+const { NetworkFirst, StaleWhileRevalidate, NetworkOnly } = workbox.strategies;
+const { BackgroundSyncPlugin } = workbox.backgroundSync;
+
 workbox.core.skipWaiting();
 workbox.core.clientsClaim();
 
@@ -16,4 +20,24 @@ self.addEventListener('activate', event => {
     )
   );
 });
+
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  new NetworkFirst({ cacheName: 'pages' })
+);
+
+registerRoute(
+  ({ request }) => ['style', 'script', 'image'].includes(request.destination),
+  new StaleWhileRevalidate({ cacheName: 'assets' })
+);
+
+const bgSyncPlugin = new BackgroundSyncPlugin('apiQueue', {
+  maxRetentionTime: 24 * 60,
+});
+
+registerRoute(
+  /\/api\//,
+  new NetworkOnly({ plugins: [bgSyncPlugin] }),
+  'POST'
+);
 

--- a/src/__tests__/useNetworkStatus.test.jsx
+++ b/src/__tests__/useNetworkStatus.test.jsx
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react';
+import useNetworkStatus from '../hooks/useNetworkStatus';
+
+test('returns current online status', () => {
+  const { result } = renderHook(() => useNetworkStatus());
+  expect(result.current).toBe(navigator.onLine);
+});
+
+test('updates when offline and online events fire', () => {
+  const { result } = renderHook(() => useNetworkStatus());
+  act(() => {
+    window.dispatchEvent(new Event('offline'));
+  });
+  expect(result.current).toBe(false);
+  act(() => {
+    window.dispatchEvent(new Event('online'));
+  });
+  expect(result.current).toBe(true);
+});
+
+

--- a/src/__tests__/usePhoneState.test.jsx
+++ b/src/__tests__/usePhoneState.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, renderHook, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import usePhoneState, { initialPhoneState } from '../hooks/usePhoneState';
 
@@ -12,3 +12,12 @@ test('usePhoneState falls back to defaults with invalid save data', () => {
   const { getByTestId } = render(<TestComponent />);
   expect(getByTestId('screen').textContent).toBe(initialPhoneState.currentScreen);
 });
+
+test('network strength updates on offline event', async () => {
+  const { result } = renderHook(() => usePhoneState());
+  act(() => {
+    window.dispatchEvent(new Event('offline'));
+  });
+  await waitFor(() => expect(result.current[0].networkStrength).toBe(0));
+});
+

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -36,7 +36,9 @@ const PhoneFrame = ({
           </div>
           <div className="flex items-center space-x-1">
             <Wifi className="w-4 h-4" />
-            <span>{networkStrength}</span>
+            <span className={networkStrength === 0 ? 'text-red-500' : ''}>
+              {networkStrength}
+            </span>
           </div>
           <div id="threat-indicator" className="flex items-center space-x-1">
             <Shield className="w-4 h-4" />

--- a/src/hooks/useNetworkStatus.js
+++ b/src/hooks/useNetworkStatus.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function useNetworkStatus() {
+  const [online, setOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);
+
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return online;
+}
+

--- a/src/hooks/useOfflineQueue.js
+++ b/src/hooks/useOfflineQueue.js
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+const KEY = 'offline-actions';
+
+export function enqueueAction(action) {
+  try {
+    const current = JSON.parse(localStorage.getItem(KEY) || '[]');
+    current.push(action);
+    localStorage.setItem(KEY, JSON.stringify(current));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function flushQueue(processor) {
+  try {
+    const current = JSON.parse(localStorage.getItem(KEY) || '[]');
+    return current.reduce(
+      (p, a) => p.then(() => processor(a)),
+      Promise.resolve()
+    ).then(() => localStorage.removeItem(KEY));
+  } catch {
+    return Promise.resolve();
+  }
+}
+
+export default function useOfflineQueue(processor) {
+  useEffect(() => {
+    if (navigator.onLine) flushQueue(processor);
+    const handle = () => flushQueue(processor);
+    window.addEventListener('online', handle);
+    return () => window.removeEventListener('online', handle);
+  }, [processor]);
+}
+

--- a/src/hooks/usePhoneState.js
+++ b/src/hooks/usePhoneState.js
@@ -67,5 +67,31 @@ export default function usePhoneState() {
     return stop;
   }, [state]);
 
+  useEffect(() => {
+    const setOnline = () => {
+      const downlink = navigator.connection && typeof navigator.connection.downlink === 'number'
+        ? navigator.connection.downlink
+        : 5;
+      setState(prev => ({
+        ...prev,
+        networkStrength: Math.min(5, Math.max(1, Math.round(downlink))),
+      }));
+    };
+
+    const setOffline = () => {
+      setState(prev => ({ ...prev, networkStrength: 0 }));
+    };
+
+    setOnline();
+    window.addEventListener('online', setOnline);
+    window.addEventListener('offline', setOffline);
+    navigator.connection && navigator.connection.addEventListener('change', setOnline);
+    return () => {
+      window.removeEventListener('online', setOnline);
+      window.removeEventListener('offline', setOffline);
+      navigator.connection && navigator.connection.removeEventListener('change', setOnline);
+    };
+  }, []);
+
   return [state, setState];
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,26 @@ root.render(
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register(
-      `${process.env.PUBLIC_URL}/service-worker.js`
-    )
+    navigator.serviceWorker
+      .register(`${process.env.PUBLIC_URL}/service-worker.js`)
       .then(registration => {
         console.log('ServiceWorker registered: ', registration);
+        if (registration.waiting) {
+          alert('Update available. Reload to apply.');
+        }
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing;
+          if (newWorker) {
+            newWorker.addEventListener('statechange', () => {
+              if (
+                newWorker.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                alert('New version available. Reload to update.');
+              }
+            });
+          }
+        });
       })
       .catch(error => {
         console.log('ServiceWorker registration failed: ', error);


### PR DESCRIPTION
## Summary
- monitor connectivity with `useNetworkStatus`
- queue offline actions via `useOfflineQueue`
- update phone UI and phone state when network status changes
- add runtime caching and background sync in service worker
- notify players about updates on page load
- document new offline mode
- test network status and phone state hooks

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68524b7ac8ac8320836f84d743e34b8e