### PR TITLE
Ensure phone frame fills viewport

### DIFF
--- a/src/__tests__/AppContainer.test.jsx
+++ b/src/__tests__/AppContainer.test.jsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+/**
+ * Ensure the active app container is visible and has height
+ * when an app is launched from the home screen.
+ */
+
+test('active app container fills available height', () => {
+  const { container, getByTestId } = render(<App />);
+  const slot0 = container.querySelector('[data-testid="grid-slot-0"]');
+  const icon = slot0.querySelector('[draggable="true"]');
+  fireEvent.click(icon);
+  const active = getByTestId('active-app');
+  expect(active).toBeInTheDocument();
+  // the active container should occupy the full height of the phone frame
+  const frame = getByTestId('phone-frame');
+  expect(frame.className).toMatch(/h-screen/);
+  expect(active.parentElement.className).toMatch(/h-full/);
+});

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -25,7 +25,8 @@ const PhoneFrame = ({
 
   return (
     <div
-      className="relative w-full min-h-screen border overflow-hidden bg-black text-green-400 flex flex-col"
+      data-testid="phone-frame"
+      className="relative w-full h-screen border overflow-hidden bg-black text-green-400 flex flex-col"
     >
       <div className={cn("flex items-center justify-between text-xs px-2 py-1", statusBarColor)}>
         <span>{time}</span>

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <AchievementsProvider>
-      <div className="relative w-full min-h-screen overflow-hidden">
+      <div className="relative w-full h-screen overflow-hidden">
         <div className="matrix-bg" />
         <App />
       </div>


### PR DESCRIPTION
## Summary
- expose phone frame with `data-testid`
- test that active app container uses full height

## Testing
- `npm test -- --runTestsByPath src/__tests__/AppContainer.test.jsx --watchAll=false`
- `npm test -- --watchAll=false` *(fails to capture full output due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68524c396278832087601bf1605548eb