### PR TITLE
Add mission system manager

### DIFF
--- a/src/components/MissionManager.jsx
+++ b/src/components/MissionManager.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import MissionBriefing from './MissionBriefing';
+import missions from '../data/missions';
+import usePhoneState from '../hooks/usePhoneState';
+
+const STORAGE_KEY = 'survivos-mission-progress';
+
+function loadProgress() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { active: null, completed: [], objectives: {} };
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray(parsed.completed) &&
+      typeof parsed.objectives === 'object'
+    ) {
+      return { active: parsed.active || null, completed: parsed.completed, objectives: parsed.objectives };
+    }
+  } catch {
+    /* ignore */
+  }
+  return { active: null, completed: [], objectives: {} };
+}
+
+function saveProgress(state) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+const MissionManager = () => {
+  const [phoneState, setPhoneState] = usePhoneState();
+  const [state, setState] = useState(() => loadProgress());
+  const activeMission = missions.find((m) => m.id === state.active);
+
+  useEffect(() => {
+    saveProgress(state);
+  }, [state]);
+
+  const startNextMission = () => {
+    if (state.active) return;
+    const next = missions.find((m) => !state.completed.includes(m.id));
+    if (next) {
+      setState((prev) => ({
+        ...prev,
+        active: next.id,
+        objectives: {
+          ...prev.objectives,
+          [next.id]: next.objectives.map(() => false),
+        },
+      }));
+    }
+  };
+
+  const completeObjective = (index) => {
+    if (!activeMission) return;
+    setState((prev) => {
+      const prog = prev.objectives[prev.active].slice();
+      prog[index] = true;
+      const newState = {
+        ...prev,
+        objectives: { ...prev.objectives, [prev.active]: prog },
+      };
+      const done = prog.every(Boolean);
+      if (done) {
+        newState.completed = [...prev.completed, prev.active];
+        newState.active = null;
+        const reward = activeMission.reward;
+        setPhoneState((ps) => {
+          const notifications = [
+            ...ps.notifications,
+            {
+              id: `${activeMission.id}-done`,
+              message: `${activeMission.title} completed`,
+              type: 'mission',
+              timestamp: Date.now(),
+            },
+          ];
+          let unlockedApps = ps.unlockedApps;
+          if (reward && !ps.unlockedApps.includes(reward)) {
+            unlockedApps = [...ps.unlockedApps, reward];
+            notifications.push({
+              id: `${activeMission.id}-reward`,
+              message: `${reward} unlocked`,
+              type: 'reward',
+              timestamp: Date.now(),
+            });
+          }
+          return { ...ps, unlockedApps, notifications };
+        });
+      }
+      return newState;
+    });
+  };
+
+  if (!activeMission) {
+    return (
+      <div className="p-4 space-y-2" data-testid="mission-manager">
+        <button
+          type="button"
+          onClick={startNextMission}
+          className="border border-green-500 text-green-400 rounded px-3 py-1"
+          data-testid="start-next"
+        >
+          Start Next Mission
+        </button>
+      </div>
+    );
+  }
+
+  const progress = state.objectives[state.active] || [];
+
+  return (
+    <div className="p-4 space-y-2" data-testid="mission-manager">
+      <MissionBriefing mission={activeMission} />
+      <ul className="space-y-1">
+        {activeMission.objectives.map((obj, idx) => (
+          <li key={idx} className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={progress[idx]}
+              onChange={() => completeObjective(idx)}
+              className="form-checkbox"
+              data-testid={`objective-${idx}`}
+            />
+            <span className="text-green-200">{obj}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MissionManager;

--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -1,0 +1,55 @@
+export const missions = [
+  {
+    id: 'tutorial-scanner',
+    type: 'tutorial',
+    title: 'Boot Camp: Scanner',
+    description: 'Learn how to use the Scanner tool to locate nearby devices.',
+    objectives: [
+      'Launch the Scanner app',
+      'Ping a nearby device',
+    ],
+    recommendedTools: ['scanner'],
+    reward: 'map',
+  },
+  {
+    id: 'defense-wave1',
+    type: 'defense',
+    title: 'Defense Drill',
+    description: 'Stop the first wave of incoming threats.',
+    objectives: ['Repel 3 threats using the Firewall'],
+    recommendedTools: ['firewall'],
+    reward: 'terminal',
+  },
+  {
+    id: 'offense-hub',
+    type: 'offense',
+    title: 'Break the Hub',
+    description: 'Hack the abandoned communications hub.',
+    objectives: ['Find the hub IP', 'Breach using the terminal'],
+    recommendedTools: ['terminal', 'portScanner'],
+    reward: 'decryptor',
+  },
+  {
+    id: 'puzzle-cipher',
+    type: 'puzzle',
+    title: 'Cipher Cache',
+    description: 'Solve the encrypted puzzle to reveal a supply cache.',
+    objectives: ['Decode the hidden message'],
+    recommendedTools: ['decryptor'],
+    reward: 'droneControl',
+  },
+  {
+    id: 'story-rescue',
+    type: 'story',
+    title: 'Contact the Resistance',
+    description: 'Establish communication with the resistance to advance the narrative.',
+    objectives: [
+      'Send a distress call using the Communicator',
+      'Transmit coordinates via the Map app',
+    ],
+    recommendedTools: ['communicator', 'map'],
+    reward: 'worldStats',
+  },
+];
+
+export default missions;


### PR DESCRIPTION
## Summary
- add mission definitions
- add `MissionManager` component to track mission progress, update phoneState and persist data

## Testing
- `CI=true npm test --silent` *(fails: LogScreen.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68526261f1188320a3150c19d8d41f55