### PR TITLE
Fix LogScreen test to match component update

### DIFF
--- a/src/__tests__/LogScreen.test.jsx
+++ b/src/__tests__/LogScreen.test.jsx
@@ -4,6 +4,6 @@ import LogScreen from '../components/LogScreen';
 
 test('displays intercepted logs', () => {
   render(<LogScreen />);
-  expect(screen.getByText(/Encrypted ping/)).toBeInTheDocument();
-  expect(screen.getByText(/Distress call/)).toBeInTheDocument();
+  expect(screen.getByText(/Log entry 1$/)).toBeInTheDocument();
+  expect(screen.getByText(/Log entry 2$/)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update LogScreen test expectations to match the new dummy log entries

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68526659e25883209723266154a53234