### PR TITLE
Add extensive unit tests

### DIFF
--- a/src/__tests__/ChemicalDatabase.test.jsx
+++ b/src/__tests__/ChemicalDatabase.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChemicalDatabase from '../components/ChemicalDatabase';
+
+// Helper to get rows of results table
+function getRows() {
+  return screen.getByTestId('query-results').querySelectorAll('tbody tr');
+}
+
+describe('ChemicalDatabase', () => {
+  test('runs default query and shows results', () => {
+    render(<ChemicalDatabase />);
+    fireEvent.click(screen.getByText('Run'));
+    const rows = getRows();
+    // default query selects organic compounds -> Water and Ethanol
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toMatch(/Water/);
+    expect(rows[1].textContent).toMatch(/Ethanol/);
+  });
+
+  test('build query updates textarea', () => {
+    render(<ChemicalDatabase />);
+    fireEvent.change(screen.getByDisplayValue(/SELECT/i), {
+      target: { value: "SELECT * FROM compounds WHERE type='inorganic'" },
+    });
+    // change builder to locations table
+    fireEvent.change(screen.getByDisplayValue('compounds'), {
+      target: { value: 'locations' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('column'), {
+      target: { value: 'id' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('value'), {
+      target: { value: '1' },
+    });
+    fireEvent.click(screen.getByText('Build'));
+    expect(screen.getByDisplayValue(/SELECT/).value).toBe(
+      "SELECT * FROM locations WHERE id='1'",
+    );
+  });
+});

--- a/src/__tests__/LeaderboardScreen.test.jsx
+++ b/src/__tests__/LeaderboardScreen.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LeaderboardScreen from '../components/LeaderboardScreen';
+import { saveHighScores } from '../lib/highscores';
+
+describe('LeaderboardScreen', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('shows message when no scores', () => {
+    render(<LeaderboardScreen />);
+    expect(screen.getByText(/No scores yet/)).toBeInTheDocument();
+  });
+
+  test('displays saved scores', () => {
+    saveHighScores([{ score: 20, threatsStopped: 2, time: 30, accuracy: 95 }]);
+    render(<LeaderboardScreen />);
+    expect(screen.getByText(/20 pts/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/MissionManager.test.jsx
+++ b/src/__tests__/MissionManager.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MissionManager from '../components/MissionManager';
+
+let mockState;
+let mockSetState;
+
+jest.mock('../hooks/usePhoneState', () => ({
+  __esModule: true,
+  default: () => [mockState, mockSetState],
+}));
+
+describe('MissionManager', () => {
+  beforeEach(() => {
+    mockState = { unlockedApps: [], notifications: [] };
+    mockSetState = jest.fn((update) => {
+      mockState = typeof update === 'function' ? update(mockState) : update;
+    });
+    localStorage.clear();
+  });
+
+  test('starts next mission and saves progress', () => {
+    render(<MissionManager />);
+    fireEvent.click(screen.getByTestId('start-next'));
+    // should show first mission objectives
+    expect(screen.getByTestId('objective-0')).toBeInTheDocument();
+    const saved = JSON.parse(localStorage.getItem('survivos-mission-progress'));
+    expect(saved.active).toBe('tutorial-scanner');
+  });
+
+  test('completing objectives unlocks reward', () => {
+    render(<MissionManager />);
+    fireEvent.click(screen.getByTestId('start-next'));
+    // complete both objectives
+    fireEvent.click(screen.getByTestId('objective-0'));
+    fireEvent.click(screen.getByTestId('objective-1'));
+    // start button should reappear
+    expect(screen.getByTestId('start-next')).toBeInTheDocument();
+    expect(mockState.unlockedApps).toContain('map');
+    expect(mockState.notifications.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/PacketAnalyzer.test.jsx
+++ b/src/__tests__/PacketAnalyzer.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PacketAnalyzer from '../components/PacketAnalyzer';
+import { getUsage, resetResources } from '../lib/resourceSystem';
+
+function mockRandom(value) {
+  jest.spyOn(Math, 'random').mockReturnValue(value);
+}
+
+describe('PacketAnalyzer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetResources();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('capture allocates and frees resources', () => {
+    mockRandom(0); // deterministic packet
+    render(<PacketAnalyzer />);
+    fireEvent.click(screen.getByText('Start Capture'));
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+    expect(getUsage().cpu).toBeGreaterThan(0);
+    const rows = screen.getByTestId('packet-table').querySelectorAll('tbody tr');
+    expect(rows.length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByText('Stop Capture'));
+    expect(getUsage().cpu).toBe(0);
+  });
+
+  test('protocol filter hides unmatched packets', () => {
+    mockRandom(0);
+    render(<PacketAnalyzer />);
+    fireEvent.click(screen.getByText('Start Capture'));
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+    const select = screen.getByLabelText('Protocol');
+    fireEvent.change(select, { target: { value: 'HTTP' } });
+    let rows = screen.getByTestId('packet-table').querySelectorAll('tbody tr');
+    expect(rows.length).toBeGreaterThan(0);
+    fireEvent.change(select, { target: { value: 'FTP' } });
+    rows = screen.getByTestId('packet-table').querySelectorAll('tbody tr');
+    expect(rows.length).toBe(0);
+  });
+});

--- a/src/__tests__/highscores.test.js
+++ b/src/__tests__/highscores.test.js
@@ -1,0 +1,25 @@
+import { loadHighScores, saveHighScores, addHighScore } from '../lib/highscores';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('loadHighScores returns empty array when none stored', () => {
+  expect(loadHighScores()).toEqual([]);
+});
+
+test('saveHighScores persists data', () => {
+  const scores = [{ score: 10 }];
+  saveHighScores(scores);
+  expect(loadHighScores()).toEqual(scores);
+});
+
+test('addHighScore sorts scores and keeps top 10', () => {
+  for (let i = 0; i < 12; i++) {
+    addHighScore({ score: i });
+  }
+  const scores = loadHighScores();
+  expect(scores.length).toBe(10);
+  expect(scores[0].score).toBe(11);
+  expect(scores[9].score).toBe(2);
+});

--- a/src/__tests__/useOfflineQueue.test.js
+++ b/src/__tests__/useOfflineQueue.test.js
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react';
+import useOfflineQueue, { enqueueAction, flushQueue } from '../hooks/useOfflineQueue';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('flushQueue processes queued actions and clears storage', async () => {
+  enqueueAction({ a: 1 });
+  enqueueAction({ a: 2 });
+  const processor = jest.fn(() => Promise.resolve());
+  await flushQueue(processor);
+  expect(processor).toHaveBeenCalledTimes(2);
+  expect(localStorage.getItem('offline-actions')).toBeNull();
+});
+
+test('useOfflineQueue registers online listener and flushes queue', async () => {
+  enqueueAction({ a: 1 });
+  const processor = jest.fn(() => Promise.resolve());
+  const addSpy = jest.spyOn(window, 'addEventListener');
+  const removeSpy = jest.spyOn(window, 'removeEventListener');
+  const { unmount } = renderHook(() => useOfflineQueue(processor));
+  await Promise.resolve();
+  expect(addSpy).toHaveBeenCalledWith('online', expect.any(Function));
+  // processor should run immediately if online
+  expect(processor).toHaveBeenCalledTimes(1);
+  act(() => {
+    window.dispatchEvent(new Event('online'));
+  });
+  await Promise.resolve();
+  expect(processor).toHaveBeenCalledTimes(2);
+  unmount();
+  expect(removeSpy).toHaveBeenCalledWith('online', expect.any(Function));
+});


### PR DESCRIPTION
## Summary
- add tests for ChemicalDatabase component
- add PacketAnalyzer tests
- cover MissionManager mission progression
- test LeaderboardScreen output
- ensure highscores functions work correctly
- cover offline queue logic

## Testing
- `npm run coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852d94635548320ac525ad115c733cc