### PR TITLE
Fix game start order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,7 +48,9 @@ const App = () => {
 
   const [phoneState] = usePhoneState();
   const [settings] = useState(() => loadSettings(detectQuality));
-  const [currentApp, setCurrentApp] = useState(null);
+  // Launch straight into the training module on initial load so the
+  // game interface is visible without selecting an app first.
+  const [currentApp, setCurrentApp] = useState('securityTraining');
   const [appProps, setAppProps] = useState({});
   const [animating, setAnimating] = useState(false);
 


### PR DESCRIPTION
## Summary
- show Security Training game on initial load so the `INITIATE HACK` prompt is visible

## Testing
- `npm test`
- `npm run e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6852da8199b4832090de999b3d955cd2