### PR TITLE
Improve test coverage

### DIFF
--- a/src/__tests__/card.test.jsx
+++ b/src/__tests__/card.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { Card } from '../components/ui/card';
+
+test('merges custom class names and forwards ref', () => {
+  const ref = React.createRef();
+  const { container } = render(<Card ref={ref} className="p-2">Hi</Card>);
+  const div = container.firstChild;
+  expect(div).toHaveClass('rounded-lg');
+  expect(div).toHaveClass('p-2');
+  expect(ref.current).toBe(div);
+});

--- a/src/__tests__/settings.test.js
+++ b/src/__tests__/settings.test.js
@@ -1,0 +1,27 @@
+import { loadSettings, saveSettings, defaultSettings } from '../lib/settings';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('loadSettings merges saved settings and applies detectQuality', () => {
+  localStorage.setItem('survivos-settings', JSON.stringify({ display: { brightness: 50 } }));
+  const detect = jest.fn(() => 'Low');
+  const settings = loadSettings(detect);
+  expect(settings.display.brightness).toBe(50);
+  expect(settings.performance.quality).toBe('Low');
+});
+
+test('loadSettings returns defaults on invalid data', () => {
+  localStorage.setItem('survivos-settings', '{bad');
+  const settings = loadSettings();
+  expect(settings.audio.masterVolume).toBe(defaultSettings.audio.masterVolume);
+});
+
+test('saveSettings writes to storage and ignores errors', () => {
+  saveSettings({ foo: 'bar' });
+  expect(localStorage.getItem('survivos-settings')).toContain('foo');
+  const spy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('fail'); });
+  expect(() => saveSettings({})).not.toThrow();
+  spy.mockRestore();
+});

--- a/src/__tests__/useAchievements.test.jsx
+++ b/src/__tests__/useAchievements.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import useAchievements, { AchievementsProvider } from '../hooks/useAchievements';
+
+const wrapper = ({ children }) => <AchievementsProvider>{children}</AchievementsProvider>;
+
+describe('useAchievements', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('loads initial progress from localStorage', () => {
+    localStorage.setItem('survivos-achievements', JSON.stringify({ 'boot-sequence': 20 }));
+    const { result } = renderHook(() => useAchievements(), { wrapper });
+    expect(result.current.progress['boot-sequence']).toBe(20);
+  });
+
+  test('addProgress updates progress and saves', () => {
+    const { result } = renderHook(() => useAchievements(), { wrapper });
+    act(() => result.current.addProgress('boot-sequence', 40));
+    expect(result.current.progress['boot-sequence']).toBe(40);
+    expect(JSON.parse(localStorage.getItem('survivos-achievements'))['boot-sequence']).toBe(40);
+  });
+
+  test('achievement notification appears once when completed multiple times', async () => {
+    jest.useFakeTimers();
+    function Test() {
+      const { addProgress } = useAchievements();
+      return <button onClick={() => addProgress('boot-sequence', 100)}>go</button>;
+    }
+    render(
+      <AchievementsProvider>
+        <Test />
+      </AchievementsProvider>
+    );
+    const btn = screen.getByRole('button');
+    act(() => { btn.click(); });
+    expect(await screen.findByText('Achievement Unlocked: Boot Sequence')).toBeInTheDocument();
+    act(() => { btn.click(); });
+    expect(screen.getAllByText('Achievement Unlocked: Boot Sequence')).toHaveLength(1);
+    act(() => jest.runAllTimers());
+    expect(screen.queryByText('Achievement Unlocked: Boot Sequence')).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Achievements context/hook
- cover settings helper functions
- test UI Card component

## Testing
- `npm test --silent`
- `npm run coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852ddb1b0b88320ac8d19883584ea39