### PR TITLE
Improve React test coverage

### DIFF
--- a/src/__tests__/PlaceholderScreen.test.jsx
+++ b/src/__tests__/PlaceholderScreen.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlaceholderScreen from '../components/PlaceholderScreen';
+
+test('renders placeholder text', () => {
+  render(<PlaceholderScreen name="Testing" />);
+  expect(screen.getByTestId('placeholder-screen')).toHaveTextContent('Testing coming soon...');
+});

--- a/src/__tests__/RadiationMonitor.test.jsx
+++ b/src/__tests__/RadiationMonitor.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RadiationMonitor from '../components/RadiationMonitor';
+
+// helper to control randomness
+const mockRandom = (value) => {
+  jest.spyOn(Math, 'random').mockReturnValue(value);
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('shows warning when radiation level is high', () => {
+  mockRandom(0.8); // level 8
+  render(<RadiationMonitor />);
+  expect(screen.getByTestId('radiation-warning')).toBeInTheDocument();
+});
+
+test('successful calibration displays message', () => {
+  jest.useFakeTimers();
+  mockRandom(0.1); // start with safe level
+  render(<RadiationMonitor />);
+  const btn = screen.getByRole('button', { name: /calibrate/i });
+  fireEvent.click(btn); // start calibration
+  // advance 5 steps so gaugeRef.current becomes 5
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+  fireEvent.click(btn); // press to stop
+  expect(screen.getByText('Calibrated!')).toBeInTheDocument();
+  jest.useRealTimers();
+});

--- a/src/__tests__/TrophyRoomScreen.test.jsx
+++ b/src/__tests__/TrophyRoomScreen.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TrophyRoomScreen from '../components/TrophyRoomScreen';
+import { ACHIEVEMENTS } from '../lib/achievements';
+
+const progress = {};
+progress[ACHIEVEMENTS[0].id] = 100;
+progress[ACHIEVEMENTS[1].id] = 100;
+
+jest.mock('../hooks/useAchievements', () => ({
+  __esModule: true,
+  default: () => ({ progress }),
+}));
+
+test('renders all achievements and overall percentage', () => {
+  const { container } = render(<TrophyRoomScreen />);
+  const expectedOverall = ((100 + 100) / ACHIEVEMENTS.length).toFixed(0) + '%';
+  expect(screen.getByText(`Overall Completion: ${expectedOverall}`)).toBeInTheDocument();
+  // one element with border per achievement
+  expect(container.querySelectorAll('div.border').length).toBe(ACHIEVEMENTS.length);
+  // completed achievements show 100%
+  expect(screen.getAllByText('100%').length).toBe(2);
+});

--- a/src/__tests__/VictoryScreen.test.jsx
+++ b/src/__tests__/VictoryScreen.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VictoryScreen from '../components/VictoryScreen';
+
+const stats = { time: 42, accuracy: 88, threatsStopped: 3, score: 9001 };
+
+test('displays statistics and unlocked items', () => {
+  render(<VictoryScreen stats={stats} unlocked={['map', 'radio']} />);
+  expect(screen.getByTestId('victory-message')).toHaveTextContent('TRAINING COMPLETE');
+  expect(screen.getByText('Time Played: 42s')).toBeInTheDocument();
+  expect(screen.getByText('MAP')).toBeInTheDocument();
+});
+
+test('restart and new game plus buttons trigger callbacks', () => {
+  const onRestart = jest.fn();
+  const onNewGamePlus = jest.fn();
+  render(
+    <VictoryScreen
+      stats={stats}
+      onRestart={onRestart}
+      onNewGamePlus={onNewGamePlus}
+      unlocked={[]}
+    />
+  );
+  fireEvent.click(screen.getByTestId('restart-button'));
+  fireEvent.click(screen.getByTestId('ngp-button'));
+  expect(onRestart).toHaveBeenCalled();
+  expect(onNewGamePlus).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add test for RadiationMonitor
- add test for TrophyRoomScreen
- add test for PlaceholderScreen
- add test for VictoryScreen

## Testing
- `npm test --silent`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6852e651311c8320ab73a71aa5e31f58