### PR TITLE
Improve coverage for simulator and generators

### DIFF
--- a/src/__tests__/DDoSSimulator.test.jsx
+++ b/src/__tests__/DDoSSimulator.test.jsx
@@ -1,0 +1,34 @@
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DDoSSimulator from '../components/DDoSSimulator';
+import { getUsage, resetResources } from '../lib/resourceSystem';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  resetResources();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('launching attack allocates resources and spawns packets', () => {
+  const { getByText, queryAllByTestId } = render(<DDoSSimulator />);
+  fireEvent.click(getByText('Launch'));
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+  expect(getUsage().bandwidth).toBeGreaterThan(0);
+  expect(queryAllByTestId('packet-flow').length).toBeGreaterThan(0);
+});
+
+test('stopping attack clears packets and frees resources', () => {
+  const { getByText, queryAllByTestId } = render(<DDoSSimulator />);
+  fireEvent.click(getByText('Launch'));
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+  fireEvent.click(getByText('Stop'));
+  expect(getUsage().bandwidth).toBe(0);
+  expect(queryAllByTestId('packet-flow').length).toBe(0);
+});

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,0 +1,17 @@
+jest.mock('react-dom/client', () => ({ createRoot: jest.fn() }));
+import * as ReactDOMClient from 'react-dom/client';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  ReactDOMClient.createRoot.mockClear();
+});
+
+test('renders App at root element', () => {
+  const render = jest.fn();
+  ReactDOMClient.createRoot.mockReturnValue({ render });
+  jest.isolateModules(() => {
+    require('../index');
+  });
+  expect(ReactDOMClient.createRoot).toHaveBeenCalledWith(document.getElementById('root'));
+  expect(render).toHaveBeenCalled();
+});

--- a/src/__tests__/startThreatGenerator.test.js
+++ b/src/__tests__/startThreatGenerator.test.js
@@ -1,0 +1,33 @@
+import { startThreatGenerator } from '../lib/threatGenerator';
+
+function mockRandomSequence(values) {
+  let i = 0;
+  jest.spyOn(Math, 'random').mockImplementation(() => {
+    const val = values[i % values.length];
+    i += 1;
+    return val;
+  });
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+test('generator invokes callback repeatedly and can stop', () => {
+  jest.useFakeTimers();
+  const threats = [];
+  // deterministic values for type, severity, timeToImpact, target
+  mockRandomSequence([0.1, 0.9, 0.5, 0.3]);
+  const stop = startThreatGenerator(t => threats.push(t), ['net']);
+  expect(threats).toHaveLength(0);
+  // run first scheduled threat
+  jest.runOnlyPendingTimers();
+  expect(threats).toHaveLength(1);
+  // run second
+  jest.runOnlyPendingTimers();
+  expect(threats).toHaveLength(2);
+  stop();
+  jest.runOnlyPendingTimers();
+  expect(threats).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary
- add tests for DDoSSimulator component
- add tests for threat generator helper
- test index entry for root render

## Testing
- `CI=true npm test --silent`
- `npm run coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_685301d0f4f48320af904edb7f1a87c7