### PR TITLE
Improve coverage for keypad and validator

### DIFF
--- a/src/__tests__/EmergencyKeypad.test.jsx
+++ b/src/__tests__/EmergencyKeypad.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmergencyKeypad from '../components/EmergencyKeypad';
+
+function clickDigit(d) {
+  const button = screen.getAllByText(d).find(el => el.tagName === 'BUTTON');
+  fireEvent.click(button);
+}
+
+function enterDigits(digits) {
+  digits.forEach(clickDigit);
+}
+
+test('calls onComplete with true for correct code', () => {
+  jest.useFakeTimers();
+  const onComplete = jest.fn();
+  render(<EmergencyKeypad code="12" onComplete={onComplete} />);
+  enterDigits(['1','2']);
+  expect(onComplete).toHaveBeenCalledWith(true);
+  expect(screen.getByText(/access granted/i)).toBeInTheDocument();
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+  expect(screen.getByTestId('display')).toHaveTextContent('----');
+  jest.useRealTimers();
+});
+
+test('shows denied for wrong code', () => {
+  jest.useFakeTimers();
+  const onComplete = jest.fn();
+  render(<EmergencyKeypad code="12" onComplete={onComplete} />);
+  enterDigits(['9','9']);
+  expect(onComplete).toHaveBeenCalledWith(false);
+  expect(screen.getByText(/denied/i)).toBeInTheDocument();
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+  expect(screen.getByTestId('display')).toHaveTextContent('----');
+  jest.useRealTimers();
+});

--- a/src/__tests__/scriptValidator.test.js
+++ b/src/__tests__/scriptValidator.test.js
@@ -27,3 +27,33 @@ test('detects infinite loop', () => {
   expect(res.isValid).toBe(false);
   expect(res.errors.some(e => e.includes('infinite loop'))).toBe(true);
 });
+
+test('rejects non-array input', () => {
+  const result = validateScript(null);
+  expect(result.isValid).toBe(false);
+  expect(result.errors).toContain('Invalid script format');
+});
+
+test('rejects empty script', () => {
+  const result = validateScript([]);
+  expect(result.isValid).toBe(false);
+  expect(result.errors).toContain('Script is empty');
+});
+
+test('errors when END appears before START', () => {
+  const earlyEnd = { id: 1, type: 'END', x: 0, y: 0 };
+  const lateStart = { id: 2, type: 'START', x: 0, y: 50 };
+  const res = validateScript([earlyEnd, lateStart]);
+  expect(res.isValid).toBe(false);
+  expect(res.errors).toContain('END block occurs before START');
+});
+
+test('detects missing parameter values', () => {
+  const startBlock = { type: 'START', x: 0, y: 0 };
+  const blockWithArray = { type: 'ACTION', x: 0, y: 50, parameters: [{ name: 'foo' }] };
+  const blockWithObj = { type: 'END', x: 0, y: 100, parameters: { bar: '' } };
+  const res = validateScript([startBlock, blockWithArray, blockWithObj]);
+  expect(res.isValid).toBe(false);
+  expect(res.errors).toContain('Missing value for foo in block 1');
+  expect(res.errors).toContain('Missing value for bar in block 2');
+});


### PR DESCRIPTION
## Summary
- add unit tests for `EmergencyKeypad`
- expand `scriptValidator` tests with edge cases

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_685310d1afc483208f22a0a2e13df5d9