### PR TITLE
Add new unit tests

### DIFF
--- a/src/__tests__/CommandLibrary.test.jsx
+++ b/src/__tests__/CommandLibrary.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CommandLibrary from '../components/scriptbuilder/CommandLibrary';
+
+test('renders available command blocks', () => {
+  render(<CommandLibrary />);
+  const library = screen.getByTestId('command-library');
+  expect(library.children).toHaveLength(4);
+  expect(screen.getByText('init')).toBeInTheDocument();
+  expect(screen.getByText('step')).toBeInTheDocument();
+  expect(screen.getByText('wait')).toBeInTheDocument();
+  expect(screen.getByText('end')).toBeInTheDocument();
+});

--- a/src/__tests__/DDoSSimulatorInputs.test.jsx
+++ b/src/__tests__/DDoSSimulatorInputs.test.jsx
@@ -1,0 +1,26 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DDoSSimulator from '../components/DDoSSimulator';
+
+describe('DDoSSimulator inputs', () => {
+  test('changing target updates select value', () => {
+    const { getByLabelText } = render(<DDoSSimulator />);
+    const select = getByLabelText('Target');
+    fireEvent.change(select, { target: { value: 'bravo' } });
+    expect(select.value).toBe('bravo');
+  });
+
+  test('changing packet size updates input value', () => {
+    const { getByLabelText } = render(<DDoSSimulator />);
+    const input = getByLabelText(/packet size/i);
+    fireEvent.change(input, { target: { value: '1024' } });
+    expect(input.value).toBe('1024');
+  });
+
+  test('changing frequency updates input value', () => {
+    const { getByLabelText } = render(<DDoSSimulator />);
+    const input = getByLabelText(/frequency/i);
+    fireEvent.change(input, { target: { value: '10' } });
+    expect(input.value).toBe('10');
+  });
+});

--- a/src/__tests__/PracticeMode.test.jsx
+++ b/src/__tests__/PracticeMode.test.jsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PracticeMode from '../components/PracticeMode';
+
+test('PracticeMode renders ApocalypseGame', () => {
+  const { getByText } = render(<PracticeMode />);
+  expect(getByText(/INITIATING NEURAL INTERFACE/i)).toBeInTheDocument();
+});
+
+test('PracticeMode uses practiceState storage key', () => {
+  const spy = jest.spyOn(Storage.prototype, 'setItem');
+  render(<PracticeMode />);
+  expect(spy).toHaveBeenCalledWith('practiceState', expect.any(String));
+  spy.mockRestore();
+});

--- a/src/__tests__/usePerformance.test.js
+++ b/src/__tests__/usePerformance.test.js
@@ -1,0 +1,41 @@
+import { renderHook, act } from '@testing-library/react';
+import { detectQuality, useRenderCount } from '../hooks/usePerformance';
+
+describe('detectQuality', () => {
+  const originalMemory = Object.getOwnPropertyDescriptor(navigator, 'deviceMemory');
+  const originalCores = Object.getOwnPropertyDescriptor(navigator, 'hardwareConcurrency');
+
+  function mockHW(mem, cores) {
+    Object.defineProperty(navigator, 'deviceMemory', { configurable: true, value: mem });
+    Object.defineProperty(navigator, 'hardwareConcurrency', { configurable: true, value: cores });
+  }
+
+  afterEach(() => {
+    if (originalMemory) Object.defineProperty(navigator, 'deviceMemory', originalMemory);
+    if (originalCores) Object.defineProperty(navigator, 'hardwareConcurrency', originalCores);
+  });
+
+  test('returns Low for weak hardware', () => {
+    mockHW(1, 1);
+    expect(detectQuality()).toBe('Low');
+  });
+
+  test('returns Medium for mid hardware', () => {
+    mockHW(3, 3);
+    expect(detectQuality()).toBe('Medium');
+  });
+
+  test('returns High for strong hardware', () => {
+    mockHW(8, 8);
+    expect(detectQuality()).toBe('High');
+  });
+});
+
+describe('useRenderCount', () => {
+  test('increments on each render', () => {
+    const { result, rerender } = renderHook(() => useRenderCount());
+    expect(result.current).toBe(1);
+    rerender();
+    expect(result.current).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for hardware performance detection and render counter
- test DDoSSimulator input behavior
- verify PracticeMode component logic
- test CommandLibrary component

## Testing
- `CI=true npm test --silent`
- `npm run coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_68532a2d16e08320819800d0e2087d00