### PR TITLE
Add additional unit tests

### DIFF
--- a/src/__tests__/highscores.test.js
+++ b/src/__tests__/highscores.test.js
@@ -23,3 +23,8 @@ test('addHighScore sorts scores and keeps top 10', () => {
   expect(scores[0].score).toBe(11);
   expect(scores[9].score).toBe(2);
 });
+
+test('loadHighScores handles malformed JSON', () => {
+  localStorage.setItem('survivos-highscores', '{bad');
+  expect(loadHighScores()).toEqual([]);
+});

--- a/src/__tests__/resourceSystem.test.js
+++ b/src/__tests__/resourceSystem.test.js
@@ -21,3 +21,10 @@ test('system crashes when usage reaches limit', () => {
   allocateResources('app2', { cpu: 100 });
   expect(systemCrashed()).toBe(true);
 });
+
+test('no allocation occurs after crash', () => {
+  allocateResources('app2', { cpu: 100 });
+  expect(systemCrashed()).toBe(true);
+  allocateResources('app3', { cpu: 10 });
+  expect(getUsage().cpu).toBe(100);
+});

--- a/src/__tests__/saveSystem.test.js
+++ b/src/__tests__/saveSystem.test.js
@@ -50,3 +50,11 @@ test('saveGame persists installedApps', () => {
   expect(data.installedApps).toEqual(['scanner']);
 });
 
+test('defaults array fields when missing', () => {
+  saveGame({ currentScreen: 'home' });
+  const data = loadGame();
+  expect(data.unlockedApps).toEqual([]);
+  expect(data.completedMissions).toEqual([]);
+  expect(data.installedApps).toEqual([]);
+});
+

--- a/src/__tests__/scriptValidator.test.js
+++ b/src/__tests__/scriptValidator.test.js
@@ -21,6 +21,23 @@ test('rejects invalid connections', () => {
   expect(result.isValid).toBe(false);
 });
 
+test('rejects missing END block', () => {
+  const result = validateScript([start, action]);
+  expect(result.isValid).toBe(false);
+  expect(result.errors).toContain('Missing END block');
+});
+
+test('handles blocks without coordinates', () => {
+  const loose = { type: 'ACTION' };
+  const res = validateScript([start, loose, end]);
+  expect(res.isValid).toBe(true);
+});
+
+test('supports string blocks', () => {
+  const result = validateScript(['START', 'END']);
+  expect(result.isValid).toBe(true);
+});
+
 test('detects infinite loop', () => {
   const loop = { id: 4, type: 'LOOP', x: 0, y: 50, parameters: {} };
   const res = validateScript([start, loop, end]);

--- a/src/__tests__/threatGenerator.test.js
+++ b/src/__tests__/threatGenerator.test.js
@@ -35,3 +35,10 @@ test('higher difficulty increases severity', () => {
   const high = generateThreat(5, components);
   expect(high.severity).toBeGreaterThan(low.severity);
 });
+
+test('bounds severity and timeToImpact', () => {
+  mockRandomSequence([0.5, 0.1, 0, 0]);
+  const threat = generateThreat(-3, ['x']);
+  expect(threat.severity).toBe(1);
+  expect(threat.timeToImpact).toBeGreaterThanOrEqual(5);
+});

--- a/src/__tests__/tutorialSystem.test.js
+++ b/src/__tests__/tutorialSystem.test.js
@@ -16,6 +16,12 @@ test('resetProgress clears data', () => {
   expect(loadProgress()).toEqual({ completed: [], activeMission: null });
 });
 
+test('loadProgress handles malformed JSON', () => {
+  localStorage.setItem('survivos-tutorial', '{bad json');
+  const data = loadProgress();
+  expect(data).toEqual({ completed: [], activeMission: null });
+});
+
 // ensure missions list includes expected ids
 test('tutorial missions defined', () => {
   const ids = tutorialMissions.map((m) => m.id);


### PR DESCRIPTION
## Summary
- cover untested branches for tutorialSystem, highscores, saveSystem, resourceSystem, scriptValidator and threatGenerator modules
- increase overall coverage

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_68532d083ae48320be1cecdafa5463af