### PR TITLE
Add tests for hooks and threat generator

### DIFF
--- a/src/__tests__/startThreatGenerator.test.js
+++ b/src/__tests__/startThreatGenerator.test.js
@@ -31,3 +31,21 @@ test('generator invokes callback repeatedly and can stop', () => {
   jest.runOnlyPendingTimers();
   expect(threats).toHaveLength(2);
 });
+
+test('stopping within callback prevents further scheduling', () => {
+  jest.useFakeTimers();
+  const threats = [];
+  let stop;
+  // deterministic values for type, severity, timeToImpact, target
+  mockRandomSequence([0.1, 0.9, 0.5, 0.3]);
+  stop = startThreatGenerator(t => {
+    threats.push(t);
+    stop();
+  }, ['net']);
+  // run first scheduled threat which calls stop()
+  jest.runOnlyPendingTimers();
+  expect(threats).toHaveLength(1);
+  // any additional timers should have been cleared
+  jest.runOnlyPendingTimers();
+  expect(threats).toHaveLength(1);
+});

--- a/src/__tests__/useAchievements.test.jsx
+++ b/src/__tests__/useAchievements.test.jsx
@@ -24,6 +24,12 @@ describe('useAchievements', () => {
     expect(JSON.parse(localStorage.getItem('survivos-achievements'))['boot-sequence']).toBe(40);
   });
 
+  test('handles malformed JSON in storage', () => {
+    localStorage.setItem('survivos-achievements', '{bad json');
+    const { result } = renderHook(() => useAchievements(), { wrapper });
+    expect(result.current.progress).toEqual({});
+  });
+
   test('achievement notification appears once when completed multiple times', async () => {
     jest.useFakeTimers();
     function Test() {

--- a/src/__tests__/useNetworkStatus.test.jsx
+++ b/src/__tests__/useNetworkStatus.test.jsx
@@ -18,4 +18,13 @@ test('updates when offline and online events fire', () => {
   expect(result.current).toBe(true);
 });
 
+test('defaults to true when navigator is undefined', () => {
+  const original = global.navigator;
+  // eslint-disable-next-line no-global-assign
+  navigator = undefined;
+  const { result } = renderHook(() => useNetworkStatus());
+  expect(result.current).toBe(true);
+  global.navigator = original;
+});
+
 

--- a/src/__tests__/useOfflineQueue.test.js
+++ b/src/__tests__/useOfflineQueue.test.js
@@ -14,6 +14,13 @@ test('flushQueue processes queued actions and clears storage', async () => {
   expect(localStorage.getItem('offline-actions')).toBeNull();
 });
 
+test('flushQueue handles invalid JSON gracefully', async () => {
+  localStorage.setItem('offline-actions', 'bad');
+  const processor = jest.fn();
+  await flushQueue(processor);
+  expect(processor).not.toHaveBeenCalled();
+});
+
 test('useOfflineQueue registers online listener and flushes queue', async () => {
   enqueueAction({ a: 1 });
   const processor = jest.fn(() => Promise.resolve());

--- a/src/__tests__/usePhoneState.test.jsx
+++ b/src/__tests__/usePhoneState.test.jsx
@@ -21,3 +21,16 @@ test('network strength updates on offline event', async () => {
   await waitFor(() => expect(result.current[0].networkStrength).toBe(0));
 });
 
+test('loads saved state from localStorage', () => {
+  const saved = {
+    version: 1,
+    currentScreen: 'home',
+    unlockedApps: ['map'],
+    completedMissions: [],
+    installedApps: [],
+  };
+  localStorage.setItem('survivos-save', JSON.stringify(saved));
+  const { result } = renderHook(() => usePhoneState());
+  expect(result.current[0].currentScreen).toBe('home');
+});
+

--- a/src/__tests__/useTutorial.test.jsx
+++ b/src/__tests__/useTutorial.test.jsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor, fireEvent } from '@testing-library/react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TutorialProvider, useTutorial } from '../hooks/useTutorial';
@@ -40,5 +40,34 @@ describe('useTutorial hook', () => {
     );
     expect(screen.getByText('Help message')).toBeInTheDocument();
     console.log('[TUTORIAL TEST] ==> Finished "showHelp" test.');
+  });
+
+  test('showHelp overlay completes on action', () => {
+    const Test = () => {
+      const { showHelp } = useTutorial();
+      React.useEffect(() => {
+        showHelp('target', 'Help message');
+      }, [showHelp]);
+      return <button id="target">Target</button>;
+    };
+    render(
+      <TutorialProvider>
+        <Test />
+      </TutorialProvider>
+    );
+    const btn = screen.getByRole('button');
+    act(() => {
+      btn.click();
+    });
+    return waitFor(() => {
+      expect(screen.queryByText('Help message')).not.toBeInTheDocument();
+    });
+  });
+
+  test('startMission activates a mission', () => {
+    const wrapper = ({ children }) => <TutorialProvider>{children}</TutorialProvider>;
+    const { result } = renderHook(() => useTutorial(), { wrapper });
+    act(() => result.current.startMission(tutorialMissions[0].id));
+    expect(result.current.activeMission).toBe(tutorialMissions[0].id);
   });
 });


### PR DESCRIPTION
## Summary
- test additional stop scenario in `startThreatGenerator`
- cover malformed localStorage for `useAchievements`
- add undefined navigator check in `useNetworkStatus`
- verify error handling in `useOfflineQueue`
- load existing save data in `usePhoneState`
- extend tutorial hook tests and cleanup

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_68532fc60c748320a464a1cae88fb995