### PR TITLE
Fix achievement notification logic

### DIFF
--- a/src/hooks/useAchievements.js
+++ b/src/hooks/useAchievements.js
@@ -31,10 +31,10 @@ export const AchievementsProvider = ({ children }) => {
       if (current < 100 && next >= 100) {
         const def = ACHIEVEMENTS.find((a) => a.id === id);
         if (def) {
-          // --- FIX STARTS HERE ---
-          // Check if the achievement is already in the recent list before adding.
-          setRecent((r) => (r.find(item => item.id === def.id) ? r : [...r, def]));
-          // --- FIX ENDS HERE ---
+          // Only push the achievement if it is not already queued for display
+          setRecent((list) =>
+            list.some((item) => item.id === def.id) ? list : [...list, def]
+          );
           setTimeout(() =>
             setRecent((r) => r.filter((d) => d.id !== id)),
           5000);


### PR DESCRIPTION
## Summary
- make sure recent achievements list gets updated correctly

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685333ef99e88320b1f4bb445ad54a91