### PR TITLE
Add failing tests for script builder issues

### DIFF
--- a/src/__tests__/ScriptBuilder.test.jsx
+++ b/src/__tests__/ScriptBuilder.test.jsx
@@ -1,0 +1,52 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScriptBuilder from '../components/scriptbuilder/ScriptBuilder';
+import * as validator from '../lib/scriptValidator';
+
+function createDataTransfer(cmd) {
+  return {
+    data: { 'text/plain': cmd },
+    setData(type, val) { this.data[type] = val; },
+    getData(type) { return this.data[type]; },
+  };
+}
+
+test('adds command via drop', () => {
+  render(<ScriptBuilder />);
+  const zone = screen.getByTestId('script-dropzone');
+  fireEvent.drop(zone, { dataTransfer: createDataTransfer('START') });
+  expect(zone.textContent).toMatch('1. START');
+});
+
+test('shows error when validation fails', () => {
+  jest.spyOn(validator, 'validateScript').mockReturnValue({ isValid: false, errors: ['bad'] });
+  render(<ScriptBuilder />);
+  const zone = screen.getByTestId('script-dropzone');
+  fireEvent.drop(zone, { dataTransfer: createDataTransfer('START') });
+  fireEvent.click(screen.getByText('Run Script'));
+  expect(screen.getByText('bad')).toBeInTheDocument();
+});
+
+test('shows visualizer on valid script', () => {
+  jest.spyOn(validator, 'validateScript').mockReturnValue({ isValid: true, errors: [] });
+  render(<ScriptBuilder />);
+  const zone = screen.getByTestId('script-dropzone');
+  fireEvent.drop(zone, { dataTransfer: createDataTransfer('START') });
+  fireEvent.click(screen.getByText('Run Script'));
+  expect(screen.getByTestId('execution-visualizer')).toBeInTheDocument();
+});
+
+test('clears visualizer on validation failure after a success', () => {
+  jest
+    .spyOn(validator, 'validateScript')
+    .mockReturnValueOnce({ isValid: true, errors: [] })
+    .mockReturnValueOnce({ isValid: false, errors: ['bad'] });
+  render(<ScriptBuilder />);
+  const zone = screen.getByTestId('script-dropzone');
+  fireEvent.drop(zone, { dataTransfer: createDataTransfer('START') });
+  fireEvent.drop(zone, { dataTransfer: createDataTransfer('END') });
+  fireEvent.click(screen.getByText('Run Script'));
+  expect(screen.getByTestId('execution-visualizer')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Run Script'));
+  expect(screen.queryByTestId('execution-visualizer')).not.toBeInTheDocument();
+});

--- a/src/__tests__/TemplateSelector.test.jsx
+++ b/src/__tests__/TemplateSelector.test.jsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TemplateSelector from '../components/scriptbuilder/TemplateSelector';
+import { scriptTemplates } from '../lib/scriptTemplates';
+
+test('calls onSelect with selected template', () => {
+  const handle = jest.fn();
+  const { getByTestId } = render(<TemplateSelector onSelect={handle} />);
+  fireEvent.change(getByTestId('template-selector'), { target: { value: 'basicScan' } });
+  expect(handle).toHaveBeenCalledWith(scriptTemplates.basicScan);
+});
+
+test('does not call onSelect when placeholder option chosen', () => {
+  const handle = jest.fn();
+  const { getByTestId } = render(<TemplateSelector onSelect={handle} />);
+  fireEvent.change(getByTestId('template-selector'), { target: { value: '' } });
+  expect(handle).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- update TemplateSelector tests to cover placeholder behavior
- add ScriptBuilder test capturing stale visualizer bug

## Testing
- `npm test -- --coverage --watchAll=false` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68533392b90c8320b288632ba1e0c4fb