### PR TITLE
Implement dynamic difficulty adjustment

### DIFF
--- a/src/__tests__/threatGenerator.test.js
+++ b/src/__tests__/threatGenerator.test.js
@@ -1,4 +1,9 @@
-import { generateThreat } from '../lib/threatGenerator';
+import {
+  generateThreat,
+  computeNextDifficulty,
+  recordPerformance,
+  resetPerformance,
+} from '../lib/threatGenerator';
 
 const components = ['net', 'db'];
 
@@ -41,4 +46,26 @@ test('bounds severity and timeToImpact', () => {
   const threat = generateThreat(-3, ['x']);
   expect(threat.severity).toBe(1);
   expect(threat.timeToImpact).toBeGreaterThanOrEqual(5);
+});
+
+describe('dynamic difficulty', () => {
+  beforeEach(() => {
+    resetPerformance();
+  });
+
+  test('computeNextDifficulty increases on high success', () => {
+    for (let i = 0; i < 5; i += 1) {
+      recordPerformance({ success: true, time: 5, damage: 0 });
+    }
+    const next = computeNextDifficulty(1);
+    expect(next).toBeGreaterThan(1);
+  });
+
+  test('computeNextDifficulty decreases when failing', () => {
+    for (let i = 0; i < 5; i += 1) {
+      recordPerformance({ success: false, time: 25, damage: 30 });
+    }
+    const next = computeNextDifficulty(3);
+    expect(next).toBeLessThan(3);
+  });
 });

--- a/src/lib/threatGenerator.js
+++ b/src/lib/threatGenerator.js
@@ -3,6 +3,64 @@ export const DEFAULT_COMPONENTS = ['network', 'database', 'services', 'kernel'];
 
 let nextId = 1;
 
+/**
+ * Track player performance for dynamic difficulty adjustments.
+ * @type {{successes:number, failures:number, totalTime:number, damage:number}}
+ */
+let performance = {
+  successes: 0,
+  failures: 0,
+  totalTime: 0,
+  damage: 0,
+};
+
+/**
+ * Resets performance metrics. Primarily for testing.
+ */
+export function resetPerformance() {
+  performance = { successes: 0, failures: 0, totalTime: 0, damage: 0 };
+}
+
+/**
+ * Records the outcome of a resolved threat.
+ * @param {Object} result
+ * @param {boolean} result.success - Whether the threat was stopped
+ * @param {number} [result.time=0] - Time taken to resolve the threat
+ * @param {number} [result.damage=0] - Health lost while resolving
+ */
+export function recordPerformance({ success, time = 0, damage = 0 }) {
+  if (success) performance.successes += 1; else performance.failures += 1;
+  performance.totalTime += time;
+  performance.damage += damage;
+}
+
+/**
+ * Determine the next difficulty level based on player performance.
+ * @param {number} current
+ * @returns {number}
+ */
+export function computeNextDifficulty(current) {
+  const attempts = performance.successes + performance.failures;
+  if (attempts === 0) {
+    return current + 0.25;
+  }
+  const successRate = performance.successes / attempts;
+  const avgTime = performance.successes
+    ? performance.totalTime / performance.successes
+    : Infinity;
+  const avgDamage = performance.damage / attempts;
+
+  let next = current;
+  if (successRate > 0.8 && avgTime < 10 && avgDamage < 5) {
+    next += 1;
+  } else if (successRate < 0.5 || avgTime > 20 || avgDamage > 15) {
+    next -= 0.5;
+  } else {
+    next += 0.25;
+  }
+  return Math.max(1, next);
+}
+
 export function generateThreat(difficulty = 1, components = DEFAULT_COMPONENTS) {
   const type = THREAT_TYPES[Math.floor(Math.random() * THREAT_TYPES.length)];
   const severity = Math.min(5, Math.max(1, Math.ceil(Math.random() * difficulty)));
@@ -26,8 +84,8 @@ export function startThreatGenerator(callback, components = DEFAULT_COMPONENTS) 
     if (!active) return;
     const delay = 10000 + Math.random() * 20000;
     timeoutId = setTimeout(() => {
+      difficulty = computeNextDifficulty(difficulty);
       const threat = generateThreat(difficulty, components);
-      difficulty += 0.5;
       callback(threat);
       schedule();
     }, delay);


### PR DESCRIPTION
## Summary
- track player performance in `threatGenerator`
- adapt threat difficulty with `computeNextDifficulty`
- expose helpers for recording and resetting performance
- verify behaviour with new unit tests

## Testing
- `CI=true npm test --silent` *(fails: TemplateSelector.test.jsx, ScriptBuilder.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_685338132bc88320b2edd0018fc16a9f