### PR TITLE
Implement game-focused phone frame

### DIFF
--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -1,18 +1,26 @@
-import React, { useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import { Battery, Wifi, Shield } from "lucide-react";
-import { cn } from "../lib/utils";
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Battery, Wifi, Shield, Menu, Monitor, Maximize2, Minimize2 } from 'lucide-react';
+import { cn } from '../lib/utils';
+import { getUsage } from '../lib/resourceSystem';
 
 const PhoneFrame = ({
   children,
-  statusBarColor = "bg-gray-900",
+  statusBarColor = 'bg-gray-900',
   batteryLevel = 100,
   networkStrength = 4,
   threatLevel = 0,
+  gameMode = false,
+  level = 1,
+  totalLevels = 1,
+  onMenu,
+  onSystem,
 }) => {
   const [time, setTime] = useState(
     new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
   );
+  const [usage, setUsage] = useState(getUsage());
+  const [fullscreen, setFullscreen] = useState(false);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -23,36 +31,97 @@ const PhoneFrame = ({
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const interval = setInterval(() => setUsage(getUsage()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (fullscreen) {
+      const el = document.documentElement;
+      if (el.requestFullscreen) el.requestFullscreen();
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  }, [fullscreen]);
+
   return (
     <div
       data-testid="phone-frame"
-      className="relative w-full h-screen border overflow-hidden bg-black text-green-400 flex flex-col"
+      className="relative w-full h-screen border overflow-hidden bg-black text-green-400 flex flex-col font-mono"
     >
-      <div className={cn("flex items-center justify-between text-xs px-2 py-1", statusBarColor)}>
-        <span>{time}</span>
-        <div className="flex items-center space-x-2">
-          <div className="flex items-center space-x-1">
-            <Battery className="w-4 h-4" />
-            <span>{batteryLevel}%</span>
-          </div>
-          <div className="flex items-center space-x-1">
-            <Wifi className="w-4 h-4" />
-            <span className={networkStrength === 0 ? 'text-red-500' : ''}>
-              {networkStrength}
-            </span>
-          </div>
-          <div id="threat-indicator" className="flex items-center space-x-1">
-            <Shield className="w-4 h-4" />
-            <span>{threatLevel}</span>
+      {!gameMode && !fullscreen && (
+        <div className={cn('flex items-center justify-between text-xs px-2 py-1', statusBarColor)}>
+          <span>{time}</span>
+          <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-1">
+              <Battery className="w-4 h-4" />
+              <span>{batteryLevel}%</span>
+            </div>
+            <div className="flex items-center space-x-1">
+              <Wifi className="w-4 h-4" />
+              <span className={networkStrength === 0 ? 'text-red-500' : ''}>{networkStrength}</span>
+            </div>
+            <div id="threat-indicator" className="flex items-center space-x-1">
+              <Shield className="w-4 h-4" />
+              <span>{threatLevel}</span>
+            </div>
           </div>
         </div>
-      </div>
+      )}
+      {gameMode && (
+        <div
+          className="flex items-center justify-between text-xs px-2 py-1 bg-gray-900 border-b border-green-500/30"
+          data-testid="game-status-bar"
+        >
+          <div className="flex items-center space-x-3">
+            <span>Lvl {level}/{totalLevels}</span>
+            <div className="flex items-center space-x-1">
+              <Shield className="w-4 h-4" />
+              <span>{threatLevel}</span>
+            </div>
+            <div className="flex space-x-2">
+              <span>CPU {usage.cpu}%</span>
+              <span>RAM {usage.ram}%</span>
+              <span>BW {usage.bandwidth}%</span>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={() => setFullscreen((f) => !f)}
+              className="p-1 hover:bg-green-900/40 rounded"
+              data-testid="fullscreen-toggle"
+            >
+              {fullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+            </button>
+            <button
+              type="button"
+              onClick={onMenu}
+              className="p-1 hover:bg-green-900/40 rounded"
+              data-testid="menu-button"
+            >
+              <Menu className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={onSystem}
+              className="px-2 py-1 border border-green-500 rounded text-xs hover:bg-green-900/40"
+              data-testid="system-button"
+            >
+              System
+            </button>
+          </div>
+        </div>
+      )}
       <div className="flex-1 overflow-auto">{children}</div>
-      <div className="flex justify-around items-center p-2 border-t border-gray-700 bg-gray-900/60">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="w-8 h-8 bg-gray-800 rounded-md" />
-        ))}
-      </div>
+      {!gameMode && !fullscreen && (
+        <div className="flex justify-around items-center p-2 border-t border-gray-700 bg-gray-900/60">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="w-8 h-8 bg-gray-800 rounded-md" />
+          ))}
+        </div>
+      )}
     </div>
   );
 };
@@ -63,6 +132,11 @@ PhoneFrame.propTypes = {
   batteryLevel: PropTypes.number,
   networkStrength: PropTypes.number,
   threatLevel: PropTypes.number,
+  gameMode: PropTypes.bool,
+  level: PropTypes.number,
+  totalLevels: PropTypes.number,
+  onMenu: PropTypes.func,
+  onSystem: PropTypes.func,
 };
 
 export default PhoneFrame;


### PR DESCRIPTION
## Summary
- add fullscreen toggle and game-specific HUD to `PhoneFrame`
- display level progress, threat count, and resource usage
- provide quick access menu and System button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685347089ff88320b91b8c7ac1b44016