### PR TITLE
Implement AppIntegration overlay system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { detectQuality } from './hooks/usePerformance';
 import PhoneFrame from './components/PhoneFrame';
 import PerformanceOverlay from './components/PerformanceOverlay';
 import ApocalypseGame from './components/Game';
+import AppIntegration from './components/AppIntegration';
 import { TutorialProvider } from './hooks/useTutorial';
 import usePhoneState from './hooks/usePhoneState';
 
@@ -21,8 +22,10 @@ const App = () => {
         networkStrength={phoneState.networkStrength}
         threatLevel={phoneState.activeThreats.length}
       >
-        <ApocalypseGame practice={practiceMode} />
-        <PerformanceOverlay show={settings.performance.debugOverlay} />
+        <AppIntegration>
+          <ApocalypseGame practice={practiceMode} />
+          <PerformanceOverlay show={settings.performance.debugOverlay} />
+        </AppIntegration>
       </PhoneFrame>
     </TutorialProvider>
   );

--- a/src/__tests__/AppIntegration.test.jsx
+++ b/src/__tests__/AppIntegration.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React, { useEffect } from 'react';
+import AppIntegration, { useAppIntegration } from '../components/AppIntegration';
+
+function Requester({ apps }) {
+  const { requestApp } = useAppIntegration();
+  useEffect(() => {
+    apps.forEach((a) => requestApp(a.id, a.props, a.cbs));
+  }, [apps, requestApp]);
+  return null;
+}
+
+test('requestApp shows overlay with props', () => {
+  render(
+    <AppIntegration>
+      <Requester apps={[{ id: 'portScanner', props: { initialTarget: '1.2.3.4' } }]} />
+    </AppIntegration>
+  );
+  expect(screen.getByTestId('integration-overlay')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('1.2.3.4')).toBeInTheDocument();
+});
+
+test('queued requests open sequentially', () => {
+  render(
+    <AppIntegration>
+      <Requester apps={[{ id: 'terminal' }, { id: 'portScanner', props: { initialTarget: '2.2.2.2' } }]} />
+    </AppIntegration>
+  );
+  // first app should be terminal
+  expect(screen.getByTestId('terminal-screen')).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('integration-close'));
+  expect(screen.getByDisplayValue('2.2.2.2')).toBeInTheDocument();
+});
+
+test('success callback fires on close', () => {
+  const onSuccess = jest.fn();
+  render(
+    <AppIntegration>
+      <Requester apps={[{ id: 'terminal', cbs: { onSuccess } }]} />
+    </AppIntegration>
+  );
+  fireEvent.click(screen.getByTestId('integration-close'));
+  expect(onSuccess).toHaveBeenCalled();
+});

--- a/src/components/AppIntegration.jsx
+++ b/src/components/AppIntegration.jsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import NetworkScanner from './NetworkScanner';
+import PortScanner from './PortScanner';
+import FirewallApp from './FirewallApp';
+import TerminalScreen from './TerminalScreen';
+
+/**
+ * Context providing API to request in-game apps.
+ */
+const AppIntegrationContext = createContext(null);
+
+export const useAppIntegration = () => useContext(AppIntegrationContext);
+
+// Map of supported apps to components.
+const APP_COMPONENTS = {
+  networkScanner: NetworkScanner,
+  portScanner: PortScanner,
+  firewall: FirewallApp,
+  terminal: TerminalScreen,
+};
+
+const overlayClasses =
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/80 transition-opacity animate-in fade-in';
+
+/**
+ * AppIntegration provider handles app request queue and overlay rendering.
+ */
+const AppIntegration = ({ children }) => {
+  const [queue, setQueue] = useState([]);
+  const [active, setActive] = useState(null);
+
+  // Request an app with optional props and callbacks.
+  const requestApp = useCallback((id, props = {}, callbacks = {}) => {
+    setQueue((q) => [...q, { id, props, callbacks }]);
+  }, []);
+
+  // Show next app when none active.
+  useEffect(() => {
+    if (!active && queue.length > 0) {
+      const [next, ...rest] = queue;
+      setActive(next);
+      setQueue(rest);
+    }
+  }, [queue, active]);
+
+  const handleClose = (result = { success: true }) => {
+    if (result.success) {
+      active?.callbacks?.onSuccess?.(result.data);
+    } else {
+      active?.callbacks?.onFail?.(result.error);
+    }
+    setActive(null);
+  };
+
+  const ActiveComp = active ? APP_COMPONENTS[active.id] : null;
+
+  return (
+    <AppIntegrationContext.Provider value={{ requestApp }}>
+      {children}
+      {ActiveComp && (
+        <div className={overlayClasses} data-testid="integration-overlay">
+          <div className="relative bg-gray-900 p-4 rounded shadow-lg w-96 max-w-full">
+            <button
+              type="button"
+              onClick={() => handleClose()}
+              className="absolute top-2 right-2 text-green-400"
+              data-testid="integration-close"
+            >
+              ×
+            </button>
+            <ActiveComp {...active.props} onComplete={handleClose} />
+          </div>
+        </div>
+      )}
+    </AppIntegrationContext.Provider>
+  );
+};
+
+AppIntegration.propTypes = {
+  children: PropTypes.node,
+};
+
+export default AppIntegration;

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -30,6 +30,7 @@ import NetworkScanner from "./NetworkScanner";
 import PortScanner from "./PortScanner";
 import FirewallApp from "./FirewallApp";
 import TerminalScreen from "./TerminalScreen";
+import { useAppIntegration } from "./AppIntegration";
 
 const toolData = {
   firewall: { cost: 50 },
@@ -99,6 +100,7 @@ const initialState = {
 };
 
 const ApocalypseGame = ({ practice = false }) => {
+  const { requestApp } = useAppIntegration() || {};
   const storageKey = practice ? "practiceState" : "gameState";
   const { addProgress } = useAchievements() || {};
   const [gameState, setGameState] = useState(() => {
@@ -140,9 +142,13 @@ const ApocalypseGame = ({ practice = false }) => {
   };
 
   const launchUtility = (id, props = {}) => {
-    setActiveUtility(id);
-    setUtilityProps(props);
-    setShowTools(false);
+    if (requestApp) {
+      requestApp(id, props);
+    } else {
+      setActiveUtility(id);
+      setUtilityProps(props);
+      setShowTools(false);
+    }
   };
 
   const closeUtility = () => {


### PR DESCRIPTION
## Summary
- introduce `AppIntegration` provider to queue app requests
- wrap the game with the provider
- route utility launches through the new API
- test integration workflow and queue behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534e11be148320906fb167e638d18c