### PR TITLE
Implement unified game navigation

### DIFF
--- a/src/__tests__/GameMenu.test.jsx
+++ b/src/__tests__/GameMenu.test.jsx
@@ -10,6 +10,10 @@ test('toggle button shows menu', () => {
 });
 
 test('keyboard shortcut opens terminal', () => {
+  localStorage.setItem(
+    'survivos-save',
+    JSON.stringify({ version: 1, unlockedApps: ['terminal'], completedMissions: [] })
+  );
   render(<GameMenu />);
   fireEvent.keyDown(window, { key: 't' });
   expect(screen.getByTestId('terminal-screen')).toBeInTheDocument();

--- a/src/__tests__/autoSave.test.js
+++ b/src/__tests__/autoSave.test.js
@@ -11,7 +11,7 @@ describe('startAutoSave', () => {
 
   test('saves at interval and stops after cleanup', () => {
     const spy = jest.spyOn(Storage.prototype, 'setItem');
-    const stop = startAutoSave(() => ({ currentScreen: 'home', unlockedApps: [], completedMissions: [] }), 1000);
+    const stop = startAutoSave(() => ({ unlockedApps: [], completedMissions: [] }), 1000);
     jest.advanceTimersByTime(1000);
     expect(spy).toHaveBeenCalled();
     spy.mockClear();

--- a/src/__tests__/saveSystem.test.js
+++ b/src/__tests__/saveSystem.test.js
@@ -5,18 +5,17 @@ beforeEach(() => {
 });
 
 test('saves and loads game data', () => {
-  saveGame({ currentScreen: 'home', unlockedApps: ['map'], completedMissions: ['m1'] });
+  saveGame({ unlockedApps: ['map'], completedMissions: ['m1'] });
   const data = loadGame();
   expect(data).toMatchObject({
     version: 1,
-    currentScreen: 'home',
     unlockedApps: ['map'],
     completedMissions: ['m1'],
   });
 });
 
 test('resetGame clears saved data', () => {
-  saveGame({ currentScreen: 'home', unlockedApps: [], completedMissions: [] });
+  saveGame({ unlockedApps: [], completedMissions: [] });
   resetGame();
   expect(loadGame()).toBeNull();
 });
@@ -29,7 +28,7 @@ test('loadGame returns null for invalid JSON', () => {
 test('loadGame returns null for mismatched version', () => {
   localStorage.setItem(
     'survivos-save',
-    JSON.stringify({ version: 2, currentScreen: 'home', unlockedApps: [], completedMissions: [] })
+    JSON.stringify({ version: 2, unlockedApps: [], completedMissions: [] })
   );
   expect(loadGame()).toBeNull();
 });
@@ -41,7 +40,6 @@ test('loadGame returns null when fields are missing', () => {
 
 test('saveGame persists installedApps', () => {
   saveGame({
-    currentScreen: 'home',
     unlockedApps: [],
     completedMissions: [],
     installedApps: ['scanner'],
@@ -51,7 +49,7 @@ test('saveGame persists installedApps', () => {
 });
 
 test('defaults array fields when missing', () => {
-  saveGame({ currentScreen: 'home' });
+  saveGame({});
   const data = loadGame();
   expect(data.unlockedApps).toEqual([]);
   expect(data.completedMissions).toEqual([]);

--- a/src/__tests__/usePhoneState.test.jsx
+++ b/src/__tests__/usePhoneState.test.jsx
@@ -4,13 +4,13 @@ import usePhoneState, { initialPhoneState } from '../hooks/usePhoneState';
 
 function TestComponent() {
   const [state] = usePhoneState();
-  return <div data-testid="screen">{state.currentScreen}</div>;
+  return <div data-testid="level">{state.batteryLevel}</div>;
 }
 
 test('usePhoneState falls back to defaults with invalid save data', () => {
   localStorage.setItem('survivos-save', '{bad json');
   const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('screen').textContent).toBe(initialPhoneState.currentScreen);
+  expect(getByTestId('level').textContent).toBe(String(initialPhoneState.batteryLevel));
 });
 
 test('network strength updates on offline event', async () => {
@@ -24,13 +24,12 @@ test('network strength updates on offline event', async () => {
 test('loads saved state from localStorage', () => {
   const saved = {
     version: 1,
-    currentScreen: 'home',
     unlockedApps: ['map'],
     completedMissions: [],
     installedApps: [],
   };
   localStorage.setItem('survivos-save', JSON.stringify(saved));
   const { result } = renderHook(() => usePhoneState());
-  expect(result.current[0].currentScreen).toBe('home');
+  expect(result.current[0].unlockedApps).toContain('map');
 });
 

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -133,6 +133,7 @@ const ApocalypseGame = ({ practice = false }) => {
   const [showTools, setShowTools] = useState(false);
   const [activeUtility, setActiveUtility] = useState(null);
   const [utilityProps, setUtilityProps] = useState({});
+  const [paused, setPaused] = useState(false);
 
   const utilityComponents = {
     networkScanner: NetworkScanner,
@@ -158,6 +159,7 @@ const ApocalypseGame = ({ practice = false }) => {
 
   const handleKeyPress = useCallback(
     (e) => {
+      if (paused) return;
       if (
         gameState.showQuestion &&
         levels[gameState.currentLevel].type === "sequence"
@@ -171,7 +173,7 @@ const ApocalypseGame = ({ practice = false }) => {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [gameState.showQuestion, gameState.currentLevel],
+    [gameState.showQuestion, gameState.currentLevel, paused],
   );
 
   useEffect(() => {
@@ -198,6 +200,7 @@ const ApocalypseGame = ({ practice = false }) => {
     gameState.bootUp,
     handleKeyPress,
     addProgress,
+    paused,
   ]);
 
   useEffect(() => {
@@ -1565,7 +1568,12 @@ TIPS FOR THIS CHALLENGE:
           )}
         </div>
       </div>
-      <GameMenu />
+      {paused && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/80 text-green-400" data-testid="pause-overlay">
+          <div className="text-xl">PAUSED - Press P to resume</div>
+        </div>
+      )}
+      <GameMenu onTogglePause={() => setPaused((p) => !p)} paused={paused} />
     </div>
   );
 };

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -38,7 +38,7 @@ function loadDefaultGrid() {
 }
 
 const HomeScreen = ({ notifications = [], onLaunchApp }) => {
-  const [phoneState, setPhoneState] = usePhoneState();
+  const [phoneState] = usePhoneState();
   const [activeApp, setActiveApp] = useState(null);
   const [lockMessage, setLockMessage] = useState('');
 
@@ -146,13 +146,11 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
       onLaunchApp(appId, props);
     } else {
       setActiveApp(appId);
-      setPhoneState((s) => ({ ...s, currentScreen: 'active-app' }));
     }
   };
 
   const closeApp = () => {
     setActiveApp(null);
-    setPhoneState((s) => ({ ...s, currentScreen: 'home' }));
   };
 
   if (activeApp) {

--- a/src/hooks/usePhoneState.js
+++ b/src/hooks/usePhoneState.js
@@ -21,7 +21,6 @@ import { loadGame, startAutoSave } from '../lib/saveSystem';
  * Initial state for the in-game phone interface.
  * @type {{
  *   isBootingUp: boolean,
- *   currentScreen: 'lock' | 'home' | 'app-drawer' | 'active-app',
  *   unlockedApps: string[],
  *   installedApps: string[],
  *   systemHealth: number,
@@ -33,7 +32,6 @@ import { loadGame, startAutoSave } from '../lib/saveSystem';
  */
 export const initialPhoneState = {
   isBootingUp: false,
-  currentScreen: 'lock',
   unlockedApps: [],
   installedApps: [],
   completedMissions: [],
@@ -60,7 +58,6 @@ export default function usePhoneState() {
 
   useEffect(() => {
     const stop = startAutoSave(() => ({
-      currentScreen: state.currentScreen,
       unlockedApps: state.unlockedApps,
       completedMissions: state.completedMissions,
     }));

--- a/src/lib/saveSystem.js
+++ b/src/lib/saveSystem.js
@@ -4,12 +4,11 @@ const VERSION = 1;
 /**
  * Saves relevant game data to localStorage.
  *
- * @param {{currentScreen:string, unlockedApps:string[], completedMissions:string[]}} state
+ * @param {{unlockedApps:string[], completedMissions:string[]}} state
  */
 export function saveGame(state) {
   const data = {
     version: VERSION,
-    currentScreen: state.currentScreen,
     unlockedApps: state.unlockedApps || [],
     completedMissions: state.completedMissions || [],
     installedApps: state.installedApps || [],
@@ -23,7 +22,7 @@ export function saveGame(state) {
 
 /**
  * Loads saved game data from localStorage.
- * @returns {{version:number, currentScreen:string, unlockedApps:string[], completedMissions:string[]}|null}
+ * @returns {{version:number, unlockedApps:string[], completedMissions:string[]}|null}
  */
 export function loadGame() {
   const raw = localStorage.getItem(STORAGE_KEY);
@@ -34,7 +33,6 @@ export function loadGame() {
       !parsed ||
       typeof parsed !== 'object' ||
       parsed.version !== VERSION ||
-      typeof parsed.currentScreen !== 'string' ||
       !Array.isArray(parsed.unlockedApps) ||
       !Array.isArray(parsed.completedMissions) ||
       (parsed.installedApps && !Array.isArray(parsed.installedApps))


### PR DESCRIPTION
## Summary
- remove phone `currentScreen` concept
- update save system and phone state to match
- expand GameMenu for dynamic tool list and breadcrumb
- add pause overlay to the game and hotkeys
- adjust HomeScreen and tests for new state

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853518145cc8320b5df652b29074f10