### PR TITLE
Implement unified navigation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Unlike traditional security training, SURVIV-OS uses intuitive drag-and-drop mec
 
 ## 🌟 Key Features
 
-### Interactive Phone Interface
-- **Realistic Mobile OS**: Complete with home screen, app drawer, and dock
+### Integrated Game Interface
+- **Game-First Flow**: The game launches immediately with phone tools available through a quick menu
+- **Swipe or ESC Menu**: Open the overlay menu with a swipe gesture or the Escape key
 - **Drag-and-Drop Apps**: Organize your security tools just like a real phone
 - **Resource Management**: Monitor CPU, RAM, and bandwidth usage
 - **Dynamic Notifications**: Real-time threat alerts and system updates

--- a/src/__tests__/GameMenu.test.jsx
+++ b/src/__tests__/GameMenu.test.jsx
@@ -20,3 +20,29 @@ test('keyboard shortcut opens terminal', () => {
   fireEvent.click(screen.getByTestId('minimize-button'));
   expect(screen.queryByTestId('terminal-screen')).not.toBeInTheDocument();
 });
+
+test('escape key toggles menu', () => {
+  render(<GameMenu />);
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(screen.getByTestId('game-menu')).toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(screen.queryByTestId('game-menu')).not.toBeInTheDocument();
+});
+
+test('breadcrumb shows active tool name', () => {
+  localStorage.setItem(
+    'survivos-save',
+    JSON.stringify({ version: 1, unlockedApps: ['terminal'], completedMissions: [] })
+  );
+  render(<GameMenu />);
+  fireEvent.keyDown(window, { key: 't' });
+  expect(screen.getByText('Game')).toBeInTheDocument();
+  expect(screen.getByText(/Terminal/i)).toBeInTheDocument();
+});
+
+test('swipe gesture opens menu', () => {
+  render(<GameMenu />);
+  fireEvent.touchStart(window, { touches: [{ clientX: 0, clientY: 0 }] });
+  fireEvent.touchEnd(window, { changedTouches: [{ clientX: 100, clientY: 0 }] });
+  expect(screen.getByTestId('game-menu')).toBeInTheDocument();
+});

--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -91,6 +91,36 @@ const GameMenu = ({ onTogglePause, paused = false }) => {
     return () => window.removeEventListener('keydown', handler);
   }, [active, onTogglePause]);
 
+  useEffect(() => {
+    let startX = null;
+    let startY = null;
+    const handleStart = (e) => {
+      if (active || open) return;
+      const t = e.touches?.[0];
+      if (!t) return;
+      startX = t.clientX;
+      startY = t.clientY;
+    };
+    const handleEnd = (e) => {
+      if (startX === null || startY === null) return;
+      const t = e.changedTouches?.[0];
+      if (!t) return;
+      const dx = t.clientX - startX;
+      const dy = t.clientY - startY;
+      if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+        toggle();
+      }
+      startX = null;
+      startY = null;
+    };
+    window.addEventListener('touchstart', handleStart);
+    window.addEventListener('touchend', handleEnd);
+    return () => {
+      window.removeEventListener('touchstart', handleStart);
+      window.removeEventListener('touchend', handleEnd);
+    };
+  }, [active, open]);
+
   const ActiveComp = active ? APPS[active]?.Component : null;
 
   return (


### PR DESCRIPTION
## Summary
- integrate new game-first navigation docs
- detect swipe gestures to open game menu
- expand GameMenu tests for menu toggle, breadcrumbs, swipe

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68535cb93588832084c6b47e1a76ddbb