### PR TITLE
Fix mobile swipe menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Unlike traditional security training, SURVIV-OS uses intuitive drag-and-drop mec
 
 ## 🌟 Key Features
 
-### Integrated Game Interface
+-### Integrated Game Interface
 - **Game-First Flow**: The game launches immediately with phone tools available through a quick menu
-- **Swipe or ESC Menu**: Open the overlay menu with a swipe gesture or the Escape key
+- **Quick Menu Controls**: Swipe left or right more than 50&nbsp;px (the menu opens as soon as you cross the threshold), press `Escape` or `M`, or tap the menu icon
 - **Drag-and-Drop Apps**: Organize your security tools just like a real phone
 - **Resource Management**: Monitor CPU, RAM, and bandwidth usage
 - **Dynamic Notifications**: Real-time threat alerts and system updates

--- a/src/__tests__/GameMenu.test.jsx
+++ b/src/__tests__/GameMenu.test.jsx
@@ -35,6 +35,6 @@ test('breadcrumb shows active tool name', () => {
 test('swipe gesture opens menu', () => {
   render(<GameMenu />);
   fireEvent.touchStart(window, { touches: [{ clientX: 0, clientY: 0 }] });
-  fireEvent.touchEnd(window, { changedTouches: [{ clientX: 100, clientY: 0 }] });
+  fireEvent.touchMove(window, { touches: [{ clientX: 80, clientY: 0 }] });
   expect(screen.getByTestId('game-menu')).toBeInTheDocument();
 });

--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -92,29 +92,43 @@ const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {
   useEffect(() => {
     let startX = null;
     let startY = null;
+    let triggered = false;
+
     const handleStart = (e) => {
       if (active || open) return;
       const t = e.touches?.[0];
       if (!t) return;
       startX = t.clientX;
       startY = t.clientY;
+      triggered = false;
     };
-    const handleEnd = (e) => {
-      if (startX === null || startY === null) return;
-      const t = e.changedTouches?.[0];
+
+    const handleMove = (e) => {
+      if (startX === null || startY === null || triggered) return;
+      const t = e.touches?.[0];
       if (!t) return;
       const dx = t.clientX - startX;
       const dy = t.clientY - startY;
-      if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+      if (Math.abs(dx) >= 50 && Math.abs(dx) > Math.abs(dy)) {
         toggle();
+        triggered = true;
+        startX = null;
+        startY = null;
       }
+    };
+
+    const handleEnd = () => {
       startX = null;
       startY = null;
+      triggered = false;
     };
+
     window.addEventListener('touchstart', handleStart);
+    window.addEventListener('touchmove', handleMove);
     window.addEventListener('touchend', handleEnd);
     return () => {
       window.removeEventListener('touchstart', handleStart);
+      window.removeEventListener('touchmove', handleMove);
       window.removeEventListener('touchend', handleEnd);
     };
   }, [active, open]);

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -104,6 +104,7 @@ const PhoneFrame = ({
             <button
               type="button"
               onClick={onMenu}
+              title="Open menu"
               className="p-1 hover:bg-green-900/40 rounded"
               data-testid="menu-button"
             >


### PR DESCRIPTION
## Summary
- handle swipe gestures on `touchmove` so the menu toggles immediately once moved far enough
- document the updated behavior in README
- update swipe test

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68536fc65a9c83209cf528552a06f89c