### PR TITLE
Fix dependency for attack effect

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -289,7 +289,13 @@ const ApocalypseGame = ({ practice = false }) => {
       }));
     }, Math.random() * 5000 + 5000);
     return () => clearTimeout(timeout);
-  }, [practice, gameState.bootUp, gameState.gameCompleted, gameState.activeAttack]);
+  }, [
+    practice,
+    gameState.bootUp,
+    gameState.gameCompleted,
+    gameState.activeAttack,
+    gameState.currentLevel,
+  ]);
 
   // When an attack starts, prompt the player to acquire the correct tool
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update random attack effect to depend on the current level

## Testing
- `CI=1 npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685396389d208320b8c1a139471a7e0a