### PR TITLE
Fix tutorial not starting automatically

### DIFF
--- a/src/__tests__/useTutorial.test.jsx
+++ b/src/__tests__/useTutorial.test.jsx
@@ -6,13 +6,10 @@ import { tutorialMissions } from '../lib/tutorialSystem';
 import React from 'react';
 
 describe('useTutorial hook', () => {
-  test('resume starts first incomplete mission', () => {
-    console.log('[TUTORIAL TEST] ==> Running "resume" test...');
+  test('autoStart begins first mission', () => {
     const wrapper = ({ children }) => <TutorialProvider>{children}</TutorialProvider>;
     const { result } = renderHook(() => useTutorial(), { wrapper });
-    act(() => result.current.resume());
     expect(result.current.activeMission).toBe(tutorialMissions[0].id);
-    console.log('[TUTORIAL TEST] ==> Finished "resume" test.');
   });
 
   test('skipTutorial marks all missions complete', () => {
@@ -34,7 +31,7 @@ describe('useTutorial hook', () => {
       return <button id="target">Target</button>;
     };
     render(
-      <TutorialProvider>
+      <TutorialProvider autoStart={false}>
         <Test />
       </TutorialProvider>
     );
@@ -51,7 +48,7 @@ describe('useTutorial hook', () => {
       return <button id="target">Target</button>;
     };
     render(
-      <TutorialProvider>
+      <TutorialProvider autoStart={false}>
         <Test />
       </TutorialProvider>
     );

--- a/src/hooks/useTutorial.js
+++ b/src/hooks/useTutorial.js
@@ -4,7 +4,7 @@ import { tutorialMissions, loadProgress, saveProgress } from '../lib/tutorialSys
 
 const TutorialContext = createContext(null);
 
-export const TutorialProvider = ({ children }) => {
+export const TutorialProvider = ({ children, autoStart = true }) => {
   const [state, setState] = useState(() => loadProgress());
   const [helpSteps, setHelpSteps] = useState(null);
 
@@ -29,6 +29,12 @@ export const TutorialProvider = ({ children }) => {
   const showHelp = useCallback((targetId, message) => {
     setHelpSteps([{ targetId, message, action: 'click' }]);
   }, []);
+
+  useEffect(() => {
+    if (autoStart) {
+      resume();
+    }
+  }, [autoStart]);
 
   const activeMission = tutorialMissions.find((m) => m.id === state.activeMission);
 


### PR DESCRIPTION
## Summary
- auto-start tutorial missions when the provider mounts
- allow turning off auto-start for tests
- update tests for new behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853a1a95c848320a80b2a19278a6a4f