### PR TITLE
Fix tutorial overlay for new UI

### DIFF
--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -157,6 +157,7 @@ const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {
       <button
         type="button"
         onClick={toggle}
+        id="menu-toggle"
         className="fixed top-2 right-2 z-40 p-1 bg-gray-800 text-green-400 rounded"
         data-testid="menu-toggle"
       >

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -74,6 +74,7 @@ const PhoneFrame = ({
         <div
           className="flex items-center justify-between text-xs px-2 py-1 bg-gray-900 border-b border-green-500/40"
           data-testid="game-status-bar"
+          id="status-bar"
         >
           <div className="flex items-center space-x-3">
             <div className="flex items-center space-x-2">

--- a/src/lib/tutorialSystem.js
+++ b/src/lib/tutorialSystem.js
@@ -6,13 +6,13 @@ export const tutorialMissions = [
     name: 'First Boot',
     steps: [
       {
-        targetId: 'search-input',
-        message: 'This is your app search. Locate tools quickly.',
-        action: 'focus',
+        targetId: 'menu-toggle',
+        message: 'Open the quick menu to access your tools.',
+        action: 'click',
       },
       {
-        targetId: 'app-grid',
-        message: 'Tap an app icon to open it.',
+        targetId: 'app-icon-scanner',
+        message: 'Launch the Scanner to begin.',
         action: 'click',
       },
     ],
@@ -49,7 +49,7 @@ export const tutorialMissions = [
     name: 'Resource Management',
     steps: [
       {
-        targetId: 'status-widgets',
+        targetId: 'status-bar',
         message: 'Monitor CPU, RAM and bandwidth here.',
         action: 'click',
       },


### PR DESCRIPTION
## Summary
- target new menu layout in tutorial steps
- give IDs to menu toggle and status bar for tutorial overlay

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853b22c28988320a993184c5bdc7431