### PR TITLE
Fix tutorial overlay step by adding app-grid ID

### DIFF
--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -196,7 +196,7 @@ const HomeScreen = ({ notifications = [], onLaunchApp }) => {
       </button>
       {showGrid && (
         <div className="flex-1 overflow-auto">
-          <div className="grid grid-cols-4 gap-2" data-testid="app-grid">
+          <div className="grid grid-cols-4 gap-2" id="app-grid" data-testid="app-grid">
             {gridSlots.map((appId, i) => {
               const def = appRegistry[appId];
               const Icon = def ? Icons[def.icon] : null;


### PR DESCRIPTION
## Summary
- ensure new layout has element with `id="app-grid"` so tutorial steps work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b347d1788320b22291653c38acc2