### PR TITLE
Refactor game start flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,33 +1,21 @@
 import React, { useState } from 'react';
 import { loadSettings } from './lib/settings';
 import { detectQuality } from './hooks/usePerformance';
-import PhoneFrame from './components/PhoneFrame';
-import PerformanceOverlay from './components/PerformanceOverlay';
-import ApocalypseGame from './components/Game';
-import AppIntegration from './components/AppIntegration';
 import { TutorialProvider } from './hooks/useTutorial';
-import usePhoneState from './hooks/usePhoneState';
+import MainGameContainer from './components/MainGameContainer';
 
 const App = () => {
   const params = new URLSearchParams(window.location.search);
   const practiceMode = params.has('practice');
 
-  const [phoneState] = usePhoneState();
   const [settings] = useState(() => loadSettings(detectQuality));
 
   return (
     <TutorialProvider>
-      <PhoneFrame
-        batteryLevel={phoneState.batteryLevel}
-        networkStrength={phoneState.networkStrength}
-        threatLevel={phoneState.activeThreats.length}
-        gameMode={true}
-      >
-        <AppIntegration>
-          <ApocalypseGame practice={practiceMode} />
-          <PerformanceOverlay show={settings.performance.debugOverlay} />
-        </AppIntegration>
-      </PhoneFrame>
+      <MainGameContainer
+        practiceMode={practiceMode}
+        showPerformance={settings.performance.debugOverlay}
+      />
     </TutorialProvider>
   );
 };

--- a/src/__tests__/AppContainer.test.jsx
+++ b/src/__tests__/AppContainer.test.jsx
@@ -3,11 +3,10 @@ import '@testing-library/jest-dom';
 import App from '../App';
 
 /**
- * Ensure the game is shown inside the phone frame on load.
+ * Game should load immediately without the phone frame.
  */
-test('game renders within phone frame', () => {
-  const { getByTestId } = render(<App />);
-  const frame = getByTestId('phone-frame');
-  expect(frame).toBeInTheDocument();
-  expect(frame).toHaveTextContent(/INITIATING NEURAL INTERFACE/i);
+test('game renders directly without phone frame', () => {
+  const { queryByTestId, getByText } = render(<App />);
+  expect(queryByTestId('phone-frame')).toBeNull();
+  expect(getByText(/INITIATING NEURAL INTERFACE/i)).toBeInTheDocument();
 });

--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -165,27 +165,32 @@ const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {
       </button>
       {open && (
         <div
-          className="fixed top-10 right-2 z-40 bg-black/80 p-2 rounded grid grid-cols-2 gap-2"
-          data-testid="game-menu"
+          className="fixed inset-0 z-40 bg-black/80 flex items-center justify-center"
+          data-testid="menu-overlay"
         >
-          {Object.entries(APPS).map(([id, { icon: Icon, label, locked }]) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() => !locked && launchApp(id)}
-              className={`flex flex-col items-center p-2 rounded hover:bg-gray-700 ${
-                locked ? 'opacity-40 cursor-not-allowed' : ''
-              }`}
-              id={`app-icon-${id}`}
-              data-testid={`menu-item-${id}`}
-            >
-              <Icon className="w-6 h-6" />
-              <span className="text-xs mt-1">{label}</span>
-              {locked && (
-                <span className="text-[10px] text-yellow-400 mt-1">LOCKED</span>
-              )}
-            </button>
-          ))}
+          <div
+            className="bg-gray-900 p-2 rounded grid grid-cols-2 gap-2"
+            data-testid="game-menu"
+          >
+            {Object.entries(APPS).map(([id, { icon: Icon, label, locked }]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => !locked && launchApp(id)}
+                className={`flex flex-col items-center p-2 rounded hover:bg-gray-700 ${
+                  locked ? 'opacity-40 cursor-not-allowed' : ''
+                }`}
+                id={`app-icon-${id}`}
+                data-testid={`menu-item-${id}`}
+              >
+                <Icon className="w-6 h-6" />
+                <span className="text-xs mt-1">{label}</span>
+                {locked && (
+                  <span className="text-[10px] text-yellow-400 mt-1">LOCKED</span>
+                )}
+              </button>
+            ))}
+          </div>
         </div>
       )}
       {ActiveComp && (

--- a/src/components/MainGameContainer.jsx
+++ b/src/components/MainGameContainer.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Smartphone, X } from 'lucide-react';
+import PhoneFrame from './PhoneFrame';
+import HomeScreen from './HomeScreen';
+import ApocalypseGame from './Game';
+import PerformanceOverlay from './PerformanceOverlay';
+import AppIntegration from './AppIntegration';
+import usePhoneState from '../hooks/usePhoneState';
+
+const MainGameContainer = ({ practiceMode = false, showPerformance = false }) => {
+  const [phoneOpen, setPhoneOpen] = useState(false);
+  const [phoneState] = usePhoneState();
+
+  return (
+    <div className="relative w-full h-full">
+      <AppIntegration>
+        <ApocalypseGame practice={practiceMode} />
+        <PerformanceOverlay show={showPerformance} />
+      </AppIntegration>
+      <button
+        type="button"
+        onClick={() => setPhoneOpen(true)}
+        className="fixed bottom-2 right-2 z-30 p-1 bg-gray-800 text-green-400 rounded"
+        data-testid="phone-toggle"
+        aria-label="Open phone"
+      >
+        <Smartphone className="w-5 h-5" />
+      </button>
+      {phoneOpen && (
+        <div
+          className="fixed inset-0 z-40 flex items-center justify-center bg-black/80"
+          data-testid="phone-overlay"
+        >
+          <div className="relative w-full max-w-xs h-full">
+            <PhoneFrame
+              batteryLevel={phoneState.batteryLevel}
+              networkStrength={phoneState.networkStrength}
+              threatLevel={phoneState.activeThreats.length}
+            >
+              <HomeScreen />
+            </PhoneFrame>
+            <button
+              type="button"
+              onClick={() => setPhoneOpen(false)}
+              className="absolute top-2 right-2 z-50 p-1 bg-gray-800 text-green-400 rounded"
+              data-testid="close-phone"
+              aria-label="Close phone"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+MainGameContainer.propTypes = {
+  practiceMode: PropTypes.bool,
+  showPerformance: PropTypes.bool,
+};
+
+export default MainGameContainer;


### PR DESCRIPTION
## Summary
- create `MainGameContainer` to show the game first and open the phone as an overlay
- display the phone by clicking a new icon
- show the game menu in a fullscreen overlay
- load `MainGameContainer` from `App`
- update tests for the new start behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68542d1837188320a31978d750d9a031