### PR TITLE
Fix Game useEffect dependencies

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -368,6 +368,8 @@ const ApocalypseGame = ({ practice = false, difficulty = 'Operative', hints: ena
     gameState.activeAttack,
     gameState.currentLevel,
     tutorialDone,
+    preset.threatRate,
+    preset.timeScale,
   ]);
 
   // When an attack starts, prompt the player to acquire the correct tool


### PR DESCRIPTION
## Summary
- include `preset.threatRate` and `preset.timeScale` in Game effect deps

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685466c573088320b0a55bf31fad2054