### PR TITLE
Implement game state manager

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -1,6 +1,16 @@
 describe('SURVIV-OS', () => {
-  it('loads the home page', () => {
+  it('blocks start during tutorial', () => {
     cy.visit('/');
+    cy.wait(2500);
+    cy.contains('INITIATE HACK').should('not.exist');
+  });
+
+  it('shows start when ready', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+      },
+    });
     cy.contains('INITIATE HACK');
   });
 });

--- a/src/__tests__/ApocalypseGame.test.jsx
+++ b/src/__tests__/ApocalypseGame.test.jsx
@@ -3,22 +3,25 @@ import '@testing-library/jest-dom';
 import ApocalypseGame from '../components/Game';
 
 describe('ApocalypseGame', () => {
-  test('shows boot message then start button', () => {
+  test('shows boot then waits for tutorial', () => {
     jest.useFakeTimers();
     render(<ApocalypseGame />);
     expect(screen.getByText(/INITIATING NEURAL INTERFACE/i)).toBeInTheDocument();
     act(() => {
       jest.advanceTimersByTime(2000);
     });
-    expect(screen.getByText(/INITIATE HACK/i)).toBeInTheDocument();
+    expect(screen.queryByText(/INITIATE HACK/i)).not.toBeInTheDocument();
     jest.useRealTimers();
   });
 
-  test('can start first challenge', () => {
+  test('can start first challenge when ready', () => {
     jest.useFakeTimers();
+    localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+    const { initGameState } = require('../lib/gameStateManager');
+    initGameState();
     render(<ApocalypseGame />);
     act(() => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(0);
     });
     fireEvent.click(screen.getByText(/INITIATE HACK/i));
     expect(

--- a/src/__tests__/gameStateManager.test.js
+++ b/src/__tests__/gameStateManager.test.js
@@ -1,0 +1,35 @@
+import {
+  GameStates,
+  initGameState,
+  startGame,
+  completeTutorial,
+  canStartGame,
+  bootComplete,
+  resetState,
+  getState,
+} from '../lib/gameStateManager';
+
+beforeEach(() => {
+  localStorage.clear();
+  resetState();
+});
+
+test('initial state loads from storage', () => {
+  localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+  initGameState();
+  expect(getState()).toBe('READY');
+});
+
+test('canStartGame false during tutorial', () => {
+  localStorage.setItem('survivos-game-state', JSON.stringify('TUTORIAL'));
+  initGameState();
+  expect(canStartGame()).toBe(false);
+});
+
+test('startGame only from READY', () => {
+  localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+  initGameState();
+  expect(startGame()).toBe(true);
+  expect(getState()).toBe(GameStates.PLAYING);
+});
+

--- a/src/lib/gameStateManager.js
+++ b/src/lib/gameStateManager.js
@@ -1,0 +1,100 @@
+const STORAGE_KEY = 'survivos-game-state';
+
+export const GameStates = {
+  BOOTING: 'BOOTING',
+  TUTORIAL: 'TUTORIAL',
+  READY: 'READY',
+  PLAYING: 'PLAYING',
+  PAUSED: 'PAUSED',
+  GAME_OVER: 'GAME_OVER',
+};
+
+let state = GameStates.BOOTING;
+
+function load() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return state;
+    const parsed = JSON.parse(raw);
+    if (Object.values(GameStates).includes(parsed)) {
+      state = parsed;
+    }
+  } catch {
+    /* ignore */
+  }
+  return state;
+}
+
+function save(next) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function initGameState() {
+  load();
+  return state;
+}
+
+export function resetState() {
+  state = GameStates.BOOTING;
+  save(state);
+}
+
+export function bootComplete() {
+  return transition(GameStates.TUTORIAL);
+}
+
+export function getState() {
+  return state;
+}
+
+function emit(next) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('gameStateChange', { detail: { state: next } }));
+  }
+}
+
+const transitions = {
+  [GameStates.BOOTING]: [GameStates.TUTORIAL],
+  [GameStates.TUTORIAL]: [GameStates.READY],
+  [GameStates.READY]: [GameStates.PLAYING],
+  [GameStates.PLAYING]: [GameStates.PAUSED, GameStates.GAME_OVER],
+  [GameStates.PAUSED]: [GameStates.PLAYING],
+  [GameStates.GAME_OVER]: [GameStates.READY],
+};
+
+function transition(next) {
+  const allowed = transitions[state] || [];
+  if (!allowed.includes(next)) return false;
+  state = next;
+  save(state);
+  emit(state);
+  return true;
+}
+
+export function canStartGame() {
+  return state !== GameStates.TUTORIAL && state !== GameStates.BOOTING;
+}
+
+export function completeTutorial() {
+  return transition(GameStates.READY);
+}
+
+export function startGame() {
+  return transition(GameStates.PLAYING);
+}
+
+export function pauseGame() {
+  return transition(GameStates.PAUSED);
+}
+
+export function resumeGame() {
+  return transition(GameStates.PLAYING);
+}
+
+export function gameOver() {
+  return transition(GameStates.GAME_OVER);
+}


### PR DESCRIPTION
## Summary
- introduce a GameStateManager with explicit state machine
- sync ApocalypseGame with the new states
- update tests for the state manager and gameplay
- expand Cypress tests to validate tutorial gating

## Testing
- `npm test`
- `npx cypress run --browser chrome` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68547c4493c08320ba24c30a62c2dced