### PR TITLE
Fix unused import in Game.jsx

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -42,7 +42,6 @@ import {
   startGame as startGameState,
   completeTutorial as finishTutorial,
   bootComplete,
-  canStartGame,
   getState as getGameState,
   pauseGame,
   resumeGame,


### PR DESCRIPTION
## Summary
- remove `canStartGame` import from `Game.jsx`

## Testing
- `npx eslint src/components/Game.jsx`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685482e94a808320aaeb9842a41118bc