### PR TITLE
Implement game reset system

### DIFF
--- a/cypress/e2e/reset.cy.js
+++ b/cypress/e2e/reset.cy.js
@@ -1,0 +1,20 @@
+describe('Game Reset', () => {
+  it('clears save data from settings screen', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-save', 'foo');
+        win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+      },
+    });
+    cy.contains('INITIATE HACK');
+    cy.get('#menu-toggle').click();
+    cy.get('[data-testid="menu-item-settings"]').click();
+    cy.contains('Reset Data').click();
+    cy.get('[data-testid="reset-confirm"]').within(() => {
+      cy.contains('Reset Game').click();
+    });
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('survivos-save')).to.be.null;
+    });
+  });
+});

--- a/src/__tests__/resetSystem.test.js
+++ b/src/__tests__/resetSystem.test.js
@@ -1,0 +1,22 @@
+import { resetGame, RESET_MODES } from '../lib/resetSystem';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('soft reset preserves achievements', () => {
+  localStorage.setItem('survivos-save', 'foo');
+  localStorage.setItem('survivos-achievements', 'bar');
+  resetGame(RESET_MODES.SOFT);
+  expect(localStorage.getItem('survivos-save')).toBeNull();
+  expect(localStorage.getItem('survivos-achievements')).toBe('bar');
+});
+
+test('hard reset removes all survivos data', () => {
+  localStorage.setItem('survivos-save', 'foo');
+  localStorage.setItem('survivos-achievements', 'bar');
+  resetGame(RESET_MODES.HARD);
+  expect(localStorage.getItem('survivos-save')).toBeNull();
+  expect(localStorage.getItem('survivos-achievements')).toBeNull();
+});
+

--- a/src/components/SettingsScreen.jsx
+++ b/src/components/SettingsScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { loadSettings, saveSettings } from '../lib/settings';
 import { detectQuality } from '../hooks/usePerformance';
+import { resetGame, RESET_MODES } from '../lib/resetSystem';
 
 const Slider = ({ label, value, onChange, min = 0, max = 1, step = 0.01 }) => (
   <label className="flex items-center space-x-2">
@@ -66,11 +67,10 @@ const SettingsScreen = () => {
     reader.readAsText(file);
   };
 
-  const resetData = () => {
-    if (window.confirm('Erase all save data?')) {
-      localStorage.removeItem('survivos-save');
-      alert('Data reset');
-    }
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  const handleReset = (mode) => {
+    resetGame(mode);
   };
 
   const save = localStorage.getItem('survivos-save') || '{}';
@@ -186,7 +186,7 @@ const SettingsScreen = () => {
         <pre className="overflow-auto border border-green-500 p-2 text-xs max-h-32">{save}</pre>
         <button onClick={exportData} className="px-2 py-1 border border-green-500">Export</button>
         <input type="file" accept="application/json" onChange={importData} className="block" />
-        <button onClick={resetData} className="px-2 py-1 border border-red-500 text-red-400">Reset Data</button>
+        <button onClick={() => setConfirmReset(true)} className="px-2 py-1 border border-red-500 text-red-400">Reset Data</button>
       </section>
 
       <section className="space-y-2">
@@ -196,6 +196,19 @@ const SettingsScreen = () => {
         <a href="https://github.com/kingpinzs/post-apoc-learn" className="underline">Documentation</a>
         <button className="px-2 py-1 border border-green-500" onClick={() => window.open('https://github.com/kingpinzs/post-apoc-learn/issues/new')}>Report Bug</button>
       </section>
+
+      {confirmReset && (
+        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50" data-testid="reset-confirm">
+          <div className="bg-gray-900 p-4 rounded space-y-2 text-center">
+            <p>Reset Progress? This will erase your current game.</p>
+            <div className="space-x-2">
+              <button onClick={() => setConfirmReset(false)} className="px-2 py-1 border border-green-500">Cancel</button>
+              <button onClick={() => { setConfirmReset(false); handleReset(RESET_MODES.SOFT); }} className="px-2 py-1 border border-yellow-500 text-yellow-400">Reset Game</button>
+              <button onClick={() => { setConfirmReset(false); handleReset(RESET_MODES.HARD); }} className="px-2 py-1 border border-red-500 text-red-400">Reset Everything</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/lib/resetSystem.js
+++ b/src/lib/resetSystem.js
@@ -1,0 +1,51 @@
+import { resetResources } from './resourceSystem';
+import { resetState } from './gameStateManager';
+import { resetProgress as resetTutorial } from './tutorialSystem';
+
+/**
+ * Modes for resetting the game.
+ * - soft: keep achievements/high scores
+ * - hard: remove all saved data
+ * - tutorial: restart tutorial only
+ */
+export const RESET_MODES = {
+  SOFT: 'soft',
+  HARD: 'hard',
+  TUTORIAL: 'tutorial',
+};
+
+/**
+ * Clears all localStorage keys that start with the survivos prefix.
+ * Certain keys may be preserved depending on the mode.
+ *
+ * @param {'soft'|'hard'|'tutorial'} mode
+ */
+function clearStorage(mode) {
+  const keys = Object.keys(localStorage);
+  for (const key of keys) {
+    if (!key.startsWith('survivos-')) continue;
+    if (mode === RESET_MODES.SOFT && key === 'survivos-achievements') continue;
+    if (mode === RESET_MODES.SOFT && key === 'survivos-highscores') continue;
+    if (mode === RESET_MODES.TUTORIAL && key !== 'survivos-tutorial') continue;
+    localStorage.removeItem(key);
+  }
+}
+
+/**
+ * Fully resets the game state and reloads the page to cancel timers
+ * and remove event listeners.
+ *
+ * @param {'soft'|'hard'|'tutorial'} [mode='soft']
+ */
+export function resetGame(mode = RESET_MODES.SOFT) {
+  clearStorage(mode);
+  if (mode === RESET_MODES.TUTORIAL) {
+    resetTutorial();
+  }
+  resetResources();
+  resetState();
+  // reload to ensure all timers and listeners are cleared
+  if (typeof window !== 'undefined') {
+    window.location.reload();
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive `resetGame` utility
- update Settings screen with reset dialog
- add tests for reset system
- cover reset via Cypress

## Testing
- `npm test -- src/__tests__/resetSystem.test.js --runInBand --verbose`
- `npm run e2e` *(fails: Cypress could not verify server)*

------
https://chatgpt.com/codex/tasks/task_e_685489a9e3f0832097844b2a5679f74a