### PR TITLE
Fix Cypress tests with hidden story overlay

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3000',
+    baseUrl: 'http://localhost:3000/post-apoc-learn',
     supportFile: false,
   },
 });

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -9,6 +9,7 @@ describe('SURVIV-OS', () => {
     cy.visit('/', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+        win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
     cy.contains('INITIATE HACK');

--- a/cypress/e2e/reset.cy.js
+++ b/cypress/e2e/reset.cy.js
@@ -4,6 +4,7 @@ describe('Game Reset', () => {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-save', 'foo');
         win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
+        win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
     cy.contains('INITIATE HACK');


### PR DESCRIPTION
## Summary
- set Cypress baseUrl to built app path
- hide story overlay in Cypress tests to make start button clickable

## Testing
- `CI=true npm test --silent`
- `HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= npx cypress run --browser electron --headless`

------
https://chatgpt.com/codex/tasks/task_e_68548dfdc7288320a29a56e4c4df5c02