### PR TITLE
Fix tutorial navigation with data attributes

### DIFF
--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -1,0 +1,14 @@
+describe('Tutorial system', () => {
+  it('highlights menu and scanner', () => {
+    cy.visit('/');
+    cy.get('[data-tutorial="menu-toggle"]').should('exist');
+    cy.get('[data-tutorial="menu-toggle"]').click();
+    cy.get('[data-tutorial="app-icon-scanner"]').should('exist');
+  });
+
+  it('shows skip when element missing', () => {
+    cy.visit('/');
+    cy.get('[data-tutorial="menu-toggle"]').invoke('remove');
+    cy.contains('Skip Step');
+  });
+});

--- a/src/__tests__/TutorialOverlay.test.jsx
+++ b/src/__tests__/TutorialOverlay.test.jsx
@@ -6,12 +6,12 @@ test('advances through steps and calls onComplete', () => {
   const handleComplete = jest.fn();
   const { getByText, queryByText } = render(
     <div>
-      <button id="step1">One</button>
-      <button id="step2">Two</button>
+      <button data-tutorial="step1">One</button>
+      <button data-tutorial="step2">Two</button>
       <TutorialOverlay
         steps={[
-          { targetId: 'step1', message: 'Click first', action: 'click' },
-          { targetId: 'step2', message: 'Click second', action: 'click' },
+          { target: 'step1', message: 'Click first', action: 'click' },
+          { target: 'step2', message: 'Click second', action: 'click' },
         ]}
         onComplete={handleComplete}
       />
@@ -19,10 +19,10 @@ test('advances through steps and calls onComplete', () => {
   );
 
   expect(getByText('Click first')).toBeInTheDocument();
-  fireEvent.click(document.getElementById('step1'));
+  fireEvent.click(document.querySelector('[data-tutorial="step1"]'));
   expect(queryByText('Click first')).not.toBeInTheDocument();
   expect(getByText('Click second')).toBeInTheDocument();
-  fireEvent.click(document.getElementById('step2'));
+  fireEvent.click(document.querySelector('[data-tutorial="step2"]'));
   expect(handleComplete).toHaveBeenCalled();
   expect(queryByText('Click second')).not.toBeInTheDocument();
 });

--- a/src/__tests__/useTutorial.test.jsx
+++ b/src/__tests__/useTutorial.test.jsx
@@ -28,7 +28,7 @@ describe('useTutorial hook', () => {
       React.useEffect(() => {
         showHelp('target', 'Help message');
       }, [showHelp]);
-      return <button id="target">Target</button>;
+      return <button data-tutorial="target">Target</button>;
     };
     render(
       <TutorialProvider autoStart={false}>
@@ -45,7 +45,7 @@ describe('useTutorial hook', () => {
       React.useEffect(() => {
         showHelp('target', 'Help message');
       }, [showHelp]);
-      return <button id="target">Target</button>;
+      return <button data-tutorial="target">Target</button>;
     };
     render(
       <TutorialProvider autoStart={false}>

--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -164,6 +164,7 @@ const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {
         type="button"
         onClick={toggle}
         id="menu-toggle"
+        data-tutorial="menu-toggle"
         className="fixed top-2 right-2 z-40 p-1 bg-gray-800 text-green-400 rounded"
         data-testid="menu-toggle"
       >
@@ -187,6 +188,7 @@ const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {
                   locked ? 'opacity-40 cursor-not-allowed' : ''
                 }`}
                 id={`app-icon-${id}`}
+                data-tutorial={`app-icon-${id}`}
                 data-testid={`menu-item-${id}`}
               >
                 <Icon className="w-6 h-6" />

--- a/src/components/PhoneFrame.jsx
+++ b/src/components/PhoneFrame.jsx
@@ -75,6 +75,7 @@ const PhoneFrame = ({
           className="flex items-center justify-between text-xs px-2 py-1 bg-gray-900 border-b border-green-500/40"
           data-testid="game-status-bar"
           id="status-bar"
+          data-tutorial="status-bar"
         >
           <div className="flex items-center space-x-3">
             <div className="flex items-center space-x-2">

--- a/src/components/ThreatIndicator.jsx
+++ b/src/components/ThreatIndicator.jsx
@@ -43,6 +43,7 @@ const ThreatIndicator = ({ threats = [], onThreatClick }) => {
   return (
     <div
       data-testid="threat-indicator"
+      data-tutorial="threat-indicator"
       onClick={onThreatClick}
       className={cn(
         'border p-2 rounded text-green-400 cursor-pointer select-none',

--- a/src/hooks/useTutorial.js
+++ b/src/hooks/useTutorial.js
@@ -26,8 +26,8 @@ export const TutorialProvider = ({ children, autoStart = true }) => {
     if (next) setState({ ...state, activeMission: next.id });
   }, [state]);
 
-  const showHelp = useCallback((targetId, message) => {
-    setHelpSteps([{ targetId, message, action: 'click' }]);
+  const showHelp = useCallback((target, message) => {
+    setHelpSteps([{ target, message, action: 'click' }]);
   }, []);
 
   useEffect(() => {

--- a/src/lib/tutorialSystem.js
+++ b/src/lib/tutorialSystem.js
@@ -6,12 +6,12 @@ export const tutorialMissions = [
     name: 'First Boot',
     steps: [
       {
-        targetId: 'menu-toggle',
+        target: 'menu-toggle',
         message: 'Open the quick menu to access your tools.',
         action: 'click',
       },
       {
-        targetId: 'app-icon-scanner',
+        target: 'app-icon-scanner',
         message: 'Launch the Scanner to begin.',
         action: 'click',
       },
@@ -22,12 +22,12 @@ export const tutorialMissions = [
     name: 'Threat Defense 101',
     steps: [
       {
-        targetId: 'threat-indicator',
+        target: 'threat-indicator',
         message: 'Watch for incoming attacks here.',
         action: 'click',
       },
       {
-        targetId: 'app-icon-firewall',
+        target: 'app-icon-firewall',
         message: 'Launch the Firewall to repel threats.',
         action: 'click',
       },
@@ -38,7 +38,7 @@ export const tutorialMissions = [
     name: 'App Mastery',
     steps: [
       {
-        targetId: 'app-icon-scriptBuilder',
+        target: 'app-icon-scriptBuilder',
         message: 'Drag blocks to build scripts.',
         action: 'click',
       },
@@ -49,7 +49,7 @@ export const tutorialMissions = [
     name: 'Resource Management',
     steps: [
       {
-        targetId: 'status-bar',
+        target: 'status-bar',
         message: 'Monitor CPU, RAM and bandwidth here.',
         action: 'click',
       },


### PR DESCRIPTION
## Summary
- rewrite TutorialOverlay to track elements via `data-tutorial` attributes
- add retry logic, skipping UI and debug info
- update tutorial steps to use `target` field
- expose `showHelp` using new step structure
- mark menu button, app icons, threat indicator and status bar with `data-tutorial`
- adjust unit tests
- add e2e tests for tutorial flow

## Testing
- `CI=true npm test --silent`
- `npx cypress run --headless` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68548ddf90108320957fb7e1d3d6576e