### PR TITLE
Fix tutorial e2e isolation

### DIFF
--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -1,4 +1,9 @@
 describe('Tutorial system', () => {
+  beforeEach(() => {
+    // Ensure no previous progress interferes with the tests
+    cy.clearLocalStorage();
+  });
+
   it('highlights menu and scanner', () => {
     cy.visit('/');
     cy.get('[data-tutorial="menu-toggle"]').should('exist');


### PR DESCRIPTION
## Summary
- clear local storage before each tutorial e2e test

## Testing
- `npm test -- --watchAll=false`
- `npx cypress run --config baseUrl=http://localhost:3000` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68549becef908320a6356b89b060d358