### PR TITLE
Fix tutorial UI tests

### DIFF
--- a/src/components/GameMenu.jsx
+++ b/src/components/GameMenu.jsx
@@ -8,6 +8,7 @@ import TerminalScreen from './TerminalScreen';
 import TrophyRoomScreen from './TrophyRoomScreen';
 import StatsScreen from './StatsScreen';
 import SettingsScreen from './SettingsScreen';
+import ScannerScreen from './ScannerScreen';
 
 const COMPONENTS = {
   NetworkScanner,
@@ -17,6 +18,7 @@ const COMPONENTS = {
   TrophyRoomScreen,
   StatsScreen,
   SettingsScreen,
+  ScannerScreen,
 };
 
 const GameMenu = ({ onTogglePause, paused = false, unlockedApps = [] }) => {

--- a/src/components/TutorialOverlay.jsx
+++ b/src/components/TutorialOverlay.jsx
@@ -62,6 +62,22 @@ const TutorialOverlay = ({ steps = [], onComplete }) => {
     return () => element.removeEventListener(action, handler);
   }, [element, index, steps]);
 
+  // detect element removal after it was found
+  useEffect(() => {
+    if (!element) return undefined;
+    let frame;
+    const check = () => {
+      if (!document.contains(element)) {
+        setElement(null);
+        setMissing(true);
+      } else {
+        frame = requestAnimationFrame(check);
+      }
+    };
+    frame = requestAnimationFrame(check);
+    return () => cancelAnimationFrame(frame);
+  }, [element]);
+
   // fire completion callback
   useEffect(() => {
     if (index === steps.length && onComplete) {


### PR DESCRIPTION
## Summary
- add missing scanner screen to game menu
- handle tutorial target removal gracefully

## Testing
- `npm test -- --watchAll=false`
- `npx cypress run --config baseUrl=http://127.0.0.1:3000/post-apoc-learn --spec cypress/e2e/tutorial.cy.js`

------
https://chatgpt.com/codex/tasks/task_e_6854a5720f3c8320a0aa88b8114bd991