### PR TITLE
Fix Cypress tests by skipping intro overlay

### DIFF
--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,12 +1,19 @@
 describe('Bottom navigation', () => {
+  const visitWithoutStory = () =>
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-story-progress', '6');
+      },
+    });
+
   it('switches to stats tab', () => {
-    cy.visit('/');
+    visitWithoutStory();
     cy.get('[data-testid="tab-stats"]').click();
     cy.get('[data-testid="stats-screen"]').should('exist');
   });
 
   it('back closes active tool', () => {
-    cy.visit('/');
+    visitWithoutStory();
     cy.get('[data-testid="tab-tools"]').click();
     cy.get('#app-icon-communicator').click();
     cy.get('[data-testid="active-app"]').should('exist');

--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -5,7 +5,11 @@ describe('Tutorial system', () => {
   });
 
   it('highlights menu and scanner', () => {
-    cy.visit('/');
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-story-progress', '6');
+      },
+    });
     cy.get('[data-tutorial="tools-tab"]').should('exist');
     // Force the click in case an overlay temporarily covers the button
     cy.get('[data-tutorial="tools-tab"]').click({ force: true });
@@ -13,7 +17,11 @@ describe('Tutorial system', () => {
   });
 
   it('shows skip when element missing', () => {
-    cy.visit('/');
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-story-progress', '6');
+      },
+    });
     cy.get('[data-tutorial="tools-tab"]').invoke('remove');
     // Wait a little longer for the Skip Step button to appear
     cy.contains('Skip Step', { timeout: 6000 });


### PR DESCRIPTION
## Summary
- update navigation and tutorial e2e tests to set `survivos-story-progress`

## Testing
- `CI=true npm test`
- `npx cypress run` *(fails: could not verify server running)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf4bd3488320986fba4342018d3c