### PR TITLE
Fix tutorial overlay attribute

### DIFF
--- a/src/components/TutorialOverlay.jsx
+++ b/src/components/TutorialOverlay.jsx
@@ -89,7 +89,10 @@ const TutorialOverlay = ({ steps = [], onComplete }) => {
   const hasRect = !!rect;
 
   return (
-    <div className="fixed inset-0 z-50 pointer-events-none">
+    <div
+      className="fixed inset-0 z-50 pointer-events-none"
+      data-tutorial={steps[index]?.targetId}
+    >
       <div className="absolute inset-0 bg-black/70" />
       {hasRect && (
         <div


### PR DESCRIPTION
## Summary
- expose the current tutorial target as a `data-tutorial` attribute on the overlay

## Testing
- `npm test --silent`
- `npm run e2e` *(fails: Cypress could not verify that server is running)*

------
https://chatgpt.com/codex/tasks/task_e_6854c35335d88320bd81253cc08bd4a9