### PR TITLE
Fix tutorial highlight for app icons

### DIFF
--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -30,7 +30,11 @@ const AppIcon = ({
   };
 
   return (
-    <div id={`app-icon-${appId}`} className="flex flex-col items-center w-16">
+    <div
+      id={`app-icon-${appId}`}
+      className="flex flex-col items-center w-16"
+      data-tutorial={`app-icon-${appId}`}
+    >
       <div
         draggable={isDraggable && !isLocked}
         onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary
- expose `data-tutorial` attribute on `AppIcon` so tutorials find icons

## Testing
- `CI=true npm test --silent`
- `npm run e2e --silent` *(fails: Cypress could not verify that the server is running)*

------
https://chatgpt.com/codex/tasks/task_e_6854c6cee5ec83209bd48f26f1d019a8