### PR TITLE
Fix tutorial highlight timing

### DIFF
--- a/src/components/TutorialOverlay.jsx
+++ b/src/components/TutorialOverlay.jsx
@@ -29,7 +29,8 @@ const TutorialOverlay = ({ steps = [], onComplete }) => {
     if (index >= steps.length) return;
     setMissing(false);
     setElement(null);
-    const delays = [0, 100, 500, 1000];
+    // Increase retries to better handle slower renders
+    const delays = [0, 100, 500, 1000, 2000];
     let attempt = 0;
     let timer;
     function search() {


### PR DESCRIPTION
## Summary
- give TutorialOverlay more time to locate elements

## Testing
- `npm test -- --watchAll=false`
- `npx cypress run` *(fails: server not detected)*

------
https://chatgpt.com/codex/tasks/task_e_6854c962074c8320a26d062575c63bee