### PR TITLE
Fix Cypress baseUrl

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3000/post-apoc-learn',
+    baseUrl: 'http://localhost:3000',
     supportFile: false,
   },
 });

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -1,12 +1,12 @@
 describe('SURVIV-OS', () => {
   it('blocks start during tutorial', () => {
-    cy.visit('/');
+    cy.visit('/post-apoc-learn');
     cy.wait(2500);
     cy.contains('INITIATE HACK').should('not.exist');
   });
 
   it('shows start when ready', () => {
-    cy.visit('/', {
+    cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));
         win.localStorage.setItem('survivos-story-progress', '6');

--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,6 +1,6 @@
 describe('Bottom navigation', () => {
   const visitWithoutStory = () =>
-    cy.visit('/', {
+    cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-story-progress', '6');
       },

--- a/cypress/e2e/reset.cy.js
+++ b/cypress/e2e/reset.cy.js
@@ -1,6 +1,6 @@
 describe('Game Reset', () => {
   it('clears save data from settings screen', () => {
-    cy.visit('/', {
+    cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-save', 'foo');
         win.localStorage.setItem('survivos-game-state', JSON.stringify('READY'));

--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -5,7 +5,7 @@ describe('Tutorial system', () => {
   });
 
   it('highlights menu and scanner', () => {
-    cy.visit('/', {
+    cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
@@ -17,7 +17,7 @@ describe('Tutorial system', () => {
   });
 
   it('shows skip when element missing', () => {
-    cy.visit('/', {
+    cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-story-progress', '6');
       },


### PR DESCRIPTION
## Summary
- update Cypress base URL to root
- update e2e tests to include `/post-apoc-learn` path

## Testing
- `npm test -- --watchAll=false`
- `npx cypress run -s cypress/e2e/tutorial.cy.js` *(fails: couldn't verify server)*

------
https://chatgpt.com/codex/tasks/task_e_6854cccab51c8320ad69ed3e89130212