### PR TITLE
Update tutorial for phone overlay interface

### DIFF
--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -4,28 +4,28 @@ describe('Tutorial system', () => {
     cy.clearLocalStorage();
   });
 
-  it('highlights menu and scanner', () => {
+  it('highlights phone toggle and scanner', () => {
     cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    // Wait for the tutorial overlay to attach to the Tools tab
-    cy.contains('Open the Tools tab', { timeout: 8000 }).should('be.visible');
+    // Wait for the tutorial overlay to attach to the phone button
+    cy.contains('Open your phone', { timeout: 8000 }).should('be.visible');
     // Force the click in case an overlay temporarily covers the button
-    cy.get('[data-tutorial="tools-tab"]').click({ force: true });
+    cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
     cy.contains('Launch the Scanner', { timeout: 8000 }).should('be.visible');
     cy.get('[data-tutorial="app-icon-scanner"]').should('exist');
   });
 
-  it('advances to next step after clicking tools tab', () => {
+  it('advances to next step after clicking phone toggle', () => {
     cy.visit('/post-apoc-learn', {
       onBeforeLoad(win) {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.contains('Open the Tools tab', { timeout: 8000 });
-    cy.get('[data-tutorial="tools-tab"]').click({ force: true });
+    cy.contains('Open your phone', { timeout: 8000 });
+    cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
     cy.contains('Launch the Scanner', { timeout: 8000 });
   });
 
@@ -35,7 +35,7 @@ describe('Tutorial system', () => {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.get('[data-tutorial="tools-tab"]').invoke('remove');
+    cy.get('[data-tutorial="phone-toggle"]').invoke('remove');
     // Wait a little longer for the Skip Step button to appear
     cy.contains('Skip Step', { timeout: 6000 });
   });

--- a/src/components/MainGameContainer.jsx
+++ b/src/components/MainGameContainer.jsx
@@ -23,6 +23,7 @@ const MainGameContainer = ({ practiceMode = false, showPerformance = false, diff
         onClick={() => setPhoneOpen(true)}
         className="fixed bottom-2 right-2 z-30 p-1 bg-gray-800 text-green-400 rounded"
         data-testid="phone-toggle"
+        data-tutorial="phone-toggle"
         aria-label="Open phone"
       >
         <Smartphone className="w-5 h-5" />

--- a/src/lib/tutorialSystem.js
+++ b/src/lib/tutorialSystem.js
@@ -6,8 +6,8 @@ export const tutorialMissions = [
     name: 'First Boot',
     steps: [
       {
-        target: 'tools-tab',
-        message: 'Open the Tools tab to access your apps.',
+        target: 'phone-toggle',
+        message: 'Open your phone to access your tools.',
         action: 'click',
       },
       {


### PR DESCRIPTION
## Summary
- update tutorial steps to begin with phone toggle
- add phone toggle data attribute for tutorial
- adjust Cypress tutorial tests for new interface

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6854e36d648c83209f80dfd512300173