### PR TITLE
Extend tutorial e2e coverage

### DIFF
--- a/cypress/e2e/tutorial.cy.js
+++ b/cypress/e2e/tutorial.cy.js
@@ -11,11 +11,15 @@ describe('Tutorial system', () => {
       },
     });
     // Wait for the tutorial overlay to attach to the phone button
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
-    // Force the click in case an overlay temporarily covers the button
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]', { timeout: 10000 }).should('exist');
+    // Ensure the listener has time to attach
+    cy.wait(100);
     cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
-    cy.contains('Launch the Scanner', { timeout: 8000 }).should('exist');
-    cy.get('[data-tutorial="app-icon-scanner"]').should('exist');
+    cy.contains('Launch the Scanner', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="app-icon-scanner"]', { timeout: 10000 }).should(
+      'exist'
+    );
   });
 
   it('advances to next step after clicking phone toggle', () => {
@@ -24,9 +28,11 @@ describe('Tutorial system', () => {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]', { timeout: 10000 }).should('exist');
+    cy.wait(100);
     cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
-    cy.contains('Launch the Scanner', { timeout: 8000 }).should('exist');
+    cy.contains('Launch the Scanner', { timeout: 10000 }).should('exist');
   });
 
   it('shows skip when element missing', () => {
@@ -46,11 +52,11 @@ describe('Tutorial system', () => {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
     cy.get('[data-tutorial="phone-toggle"]').then(($btn) => {
       $btn.remove();
     });
-    cy.contains('Skip Step', { timeout: 8000 }).should('exist');
+    cy.contains('Skip Step', { timeout: 10000 }).should('exist');
   });
 
   it('completes mission after clicking scanner', () => {
@@ -59,10 +65,14 @@ describe('Tutorial system', () => {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]', { timeout: 10000 }).should('exist');
+    cy.wait(100);
     cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
-    cy.contains('Launch the Scanner', { timeout: 8000 }).should('exist');
-    cy.get('[data-tutorial="app-icon-scanner"]').click({ force: true });
+    cy.contains('Launch the Scanner', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="app-icon-scanner"]', { timeout: 10000 }).click({
+      force: true,
+    });
     cy.contains('Launch the Scanner').should('not.exist');
   });
 
@@ -72,9 +82,9 @@ describe('Tutorial system', () => {
         win.localStorage.setItem('survivos-story-progress', '6');
       },
     });
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
     cy.reload();
-    cy.contains('Open your phone', { timeout: 8000 }).should('exist');
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
   });
 
   it('skip button advances to next step', () => {
@@ -84,8 +94,8 @@ describe('Tutorial system', () => {
       },
     });
     cy.get('[data-tutorial="phone-toggle"]').invoke('remove');
-    cy.contains('Skip Step', { timeout: 8000 }).click();
-    cy.contains('Launch the Scanner', { timeout: 8000 }).should('exist');
+    cy.contains('Skip Step', { timeout: 10000 }).click();
+    cy.contains('Launch the Scanner', { timeout: 10000 }).should('exist');
   });
 
   it('does not show tutorial when all missions completed', () => {

--- a/cypress/e2e/tutorialFull.cy.js
+++ b/cypress/e2e/tutorialFull.cy.js
@@ -1,0 +1,78 @@
+describe('Full tutorial progression', () => {
+  const visitWith = (progress, gameState) => {
+    cy.visit('/post-apoc-learn', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('survivos-story-progress', '6');
+        if (progress) {
+          win.localStorage.setItem('survivos-tutorial', JSON.stringify(progress));
+        }
+        if (gameState) {
+          win.localStorage.setItem('survivos-game-state', JSON.stringify(gameState));
+        }
+      },
+    });
+  };
+
+  it('completes first mission', () => {
+    visitWith();
+    cy.contains('Open your phone', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]', { timeout: 10000 }).should('exist');
+    cy.wait(100);
+    cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
+    cy.contains('Launch the Scanner', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="app-icon-scanner"]', { timeout: 10000 }).click({ force: true });
+    cy.contains('Watch for incoming attacks here.', { timeout: 10000 }).should('exist');
+    cy.window().then((win) => {
+      const data = JSON.parse(win.localStorage.getItem('survivos-tutorial'));
+      expect(data.completed).to.include('firstBoot');
+    });
+  });
+
+  it('completes threat defense mission', () => {
+    visitWith({ completed: ['firstBoot'], activeMission: null });
+    cy.contains('Watch for incoming attacks here.', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="threat-indicator"]', { timeout: 10000 }).click({ force: true });
+    cy.contains('Launch the Firewall', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
+    cy.get('[data-tutorial="app-icon-firewall"]', { timeout: 10000 }).click({ force: true });
+    cy.window().then((win) => {
+      const data = JSON.parse(win.localStorage.getItem('survivos-tutorial'));
+      expect(data.completed).to.include('threatDefense');
+    });
+  });
+
+  it('completes app mastery mission', () => {
+    visitWith({ completed: ['firstBoot', 'threatDefense'], activeMission: null });
+    cy.contains('Drag blocks to build scripts.', { timeout: 10000 }).should('exist');
+    cy.get('[data-tutorial="phone-toggle"]').click({ force: true });
+    cy.get('[data-tutorial="app-icon-scriptBuilder"]', { timeout: 10000 }).click({ force: true });
+    cy.window().then((win) => {
+      const data = JSON.parse(win.localStorage.getItem('survivos-tutorial'));
+      expect(data.completed).to.include('appMastery');
+    });
+  });
+
+  it('completes resource management mission', () => {
+    visitWith({ completed: ['firstBoot', 'threatDefense', 'appMastery'], activeMission: null });
+    cy.contains('Monitor CPU, RAM and bandwidth here.', { timeout: 10000 }).should('exist');
+    cy.contains('Skip Step', { timeout: 10000 }).click();
+    cy.window().then((win) => {
+      const data = JSON.parse(win.localStorage.getItem('survivos-tutorial'));
+      expect(data.completed).to.include('resourceMgmt');
+    });
+  });
+
+  it('shows start button after tutorial and can begin game', () => {
+    visitWith(
+      {
+        completed: ['firstBoot', 'threatDefense', 'appMastery', 'resourceMgmt'],
+        activeMission: null,
+      },
+      'READY'
+    );
+    cy.contains('INITIATE HACK', { timeout: 10000 })
+      .should('exist')
+      .click();
+    cy.contains('INITIATE HACK').should('not.exist');
+  });
+});


### PR DESCRIPTION
## Summary
- improve stability of existing tutorial tests
- add new e2e suite that walks through all tutorial missions

## Testing
- `npm run build`
- `npx http-server ./build -p 3000` *(fails: address already in use)*
- `npx cypress run` *(fails: server not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854f2d22658832089fb85493544110c